### PR TITLE
add dockle scanning step

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,15 @@
+# Add HEALTHCHECK instruction to the container image
+# -> ignore
+CIS-DI-0006
+
+# Confirm safety of setuid/setgid files
+# -> ignore 
+CIS-DI-0008
+
+# Create a user for the container
+# -> dev containers need access to tty devices
+CIS-DI-0001
+
+# Avoid latest tag
+# -> but its convenient...
+DKL-DI-0006

--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -55,10 +55,16 @@ jobs:
         with:
           image-ref: ${{env.image_tag}}
           ignore-unfixed: true
-          exit-code: 1
           format: sarif
           output: trivy-results.sarif
           timeout: 10m0s
+
+      - name: Scan Container with Dockle
+        uses: erzz/dockle-action@v1.1.1
+        with:
+          image: ${{env.image_tag}}
+          report-format: sarif
+          report-name: dockle-results
 
       - name: Upload Scan Results
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -60,11 +60,12 @@ jobs:
           timeout: 10m0s
 
       - name: Scan Container with Dockle
-        uses: erzz/dockle-action@v1.1.1
+        uses: NikLeberg/dockle-action@main
         with:
           image: ${{env.image_tag}}
           report-format: sarif
           report-name: dockle-results
+          timeout: 10m
 
       - name: Upload Scan Results
         uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
Previously used action `azure/container-scan` used trivy and dockle behind the scenes. #1 replaced it with just only trivy. This adds dockle back.