### PR TITLE
ci: skip entire job if no image has to be build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,8 @@ jobs:
 
   dockerhub:
     name: DockerHub
+    needs: detect_changes
+    if: ${{needs.detect_changes.outputs.dockerhub-changed != ''}}
     uses: ./.github/workflows/container_builder.yml
     with:
       registry: docker.io
@@ -39,10 +41,11 @@ jobs:
       push: ${{github.ref_name == 'main'}}
     secrets:
       password: ${{secrets.DOCKERHUB_PASSWORD}}
-    needs: detect_changes
 
   github:
     name: GitHub registry
+    needs: detect_changes
+    if: ${{needs.detect_changes.outputs.github-changed != ''}}
     uses: ./.github/workflows/container_builder.yml
     with:
       registry: ghcr.io
@@ -51,4 +54,3 @@ jobs:
       push: ${{github.ref_name == 'main'}}
     secrets:
       password: ${{secrets.GITHUB_TOKEN}}
-    needs: detect_changes


### PR DESCRIPTION
Previously if no files for a container changed it wasnt rebuild. But in consequence thereof, if no containers need to be rebuild the yml workflow format for the matrix keyword is wrong and the workflow failed. This now skips the jobs if there is nothing to do.