### PR TITLE
ci: switch back to erzz dockle action

### DIFF
--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -57,7 +57,7 @@ jobs:
           timeout: 10m0s
 
       - name: Scan Container with Dockle
-        uses: NikLeberg/dockle-action@main
+        uses: erzz/dockle-action@v1.2.0
         with:
           image: ${{env.image_tag}}
           report-format: sarif


### PR DESCRIPTION
The proposed [pr](https://github.com/erzz/dockle-action/pull/7)   for the `erzz/dockle-action` was accepted. Now the timeout input option is supported in the upstream version. As such the local fork is no longer necessary and can be replaced with upstream.