### PR TITLE
tdd-platform: update klee to v2.3

### DIFF
--- a/tdd-platform/Dockerfile
+++ b/tdd-platform/Dockerfile
@@ -52,10 +52,10 @@ RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
         python /usr/bin/python3.9
 
 # Install packages for KLEE symbolic execution support.
-ARG STP_CLONE_URL=https://github.com/stp/stp
+ARG STP_CLONE_URL=https://github.com/stp/stp.git
 ARG STP_CLONE_TAG=2.3.3
 ARG KLEE_CLONE_URL=https://github.com/klee/klee.git
-ARG KLEE_CLONE_TAG=master
+ARG KLEE_CLONE_TAG=v2.3
 
 RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
         zlib1g-dev \
@@ -82,11 +82,9 @@ RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
     && cmake -S klee -B klee/build \
         -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_SOLVER_STP=ON \
-        -DENABLE_SOLVER_Z3=ON \
         -DKLEE_RUNTIME_BUILD_TYPE=Release \
         -DENABLE_TCMALLOC=OFF \
         -DENABLE_SYSTEM_TESTS=OFF \
-        -DENABLE_DOCS=OFF \
     && make -C klee/build install \
     && rm -rf klee \
     && pip install wllvm tabulate

--- a/tdd-platform/tests.dockerfile
+++ b/tdd-platform/tests.dockerfile
@@ -4,13 +4,10 @@ FROM ghcr.io/nikleberg/tdd-platform:latest
 
 RUN git clone https://github.com/NikLeberg/tdd-platform.git --recurse-submodules \
     && cd tdd-platform \
-    && git reset --hard 689b179
+    && git reset --hard 4516b17
 
 SHELL ["/bin/bash", "-c"]
 WORKDIR /tdd-platform
-
-RUN cmake -S . -B build/linux -DPLATFORM=linux \
-    && make -C build/linux all
 
 RUN source platform/esp32/environment.sh \
     && cmake -S . -B build/esp32 -DPLATFORM=esp32 \
@@ -23,3 +20,9 @@ RUN source platform/esp8266/environment.sh \
 RUN source platform/carme-m4/environment.sh \
     && cmake -S . -B build/carme-m4 -DPLATFORM=carme-m4 \
     && make -C build/carme-m4 all
+
+# Also test fuzzing and symbolic execution.
+RUN cmake -S . -B build/linux -DPLATFORM=linux \
+    && make -C build/linux all \
+    && make -C build/linux fuzzing_buggy_api_run || true \
+    && make -C build/linux symbolic_buggy_api_run


### PR DESCRIPTION
[KLEE](https://github.com/klee/klee) v2.3 was just released. Update to the newest version.