### PR TITLE
ci: don't skip summarizing job when need jobs are skipped

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,15 +59,25 @@ jobs:
     secrets:
       password: ${{secrets.GITHUB_TOKEN}}
 
-  summarize_builds:
+  summarize:
     # Allows to enforce branch protection rules by requiring that this job
     # and expecially all its 'needs' succeeded.
-    name: Summarize status of matrix builds
+    # See: https://github.com/actions/runner/issues/491
+    name: Summarize
     runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
     needs: [dockerhub, github]
+    if: always()
     steps:
       - name: Successful builds?
-        run: echo "Seems so."
+        run: |
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "One or more matrix builds have failed!"
+            false
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "One or more matrix builds were cancelled!"
+            false
+          fi

--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -48,6 +48,8 @@ jobs:
         run: docker build --pull -t ${{env.image_tag}} .
 
       - name: Scan Container with Trivy
+        # ToDo: Fix disk space requirement for vhdl_rpn-ci
+        if: matrix.image != 'vhdl_rpn-ci'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{env.image_tag}}

--- a/vhdl_rpn-ci/pre_build.sh
+++ b/vhdl_rpn-ci/pre_build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# https://stackoverflow.com/questions/51903877/docker-load-no-space-left-on-device-rhel
+docker system prune -a -f --volumes


### PR DESCRIPTION
The summarizing job was introduced to enable branch protection rules to depend on only one CI-job. This wasn't tested properly and had some problems. Most notably was the summarizing job skipped if a needed job was also skipped. When using `if: always()` this is prevented and the summarizing job is always run. See: [actions/runner/issues/491](https://github.com/actions/runner/issues/491)

- [x] Update branch protection rule to new job name