### PR TITLE
ci: allow for manual dispatch of action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   # Names of container images for their respective registries. (Space separated)


### PR DESCRIPTION
Enable manual triggering for Action according to the [docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
Usable to trigger new container builds with updated apt packages. 