### PR TITLE
ci: fix usage of wrong dockle version

### DIFF
--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -66,6 +66,7 @@ jobs:
           failure-threshold: FATAL
           exit-code: 1
           timeout: 10m
+          dockle-version: "0.4.5"
 
       - name: Upload Scan Results
         if: steps.pre_build.outputs.trivy_skip != 'skip'


### PR DESCRIPTION
The `erzz/dockle-action` automatically tries to use the latest release of  [goodwithtech/dockle](https://github.com/goodwithtech/dockle/). However the tags of that repository are no longer linear and the parsing for the latest release does not work anymore. Fall back to a fixed version.