### PR TITLE
android-ci: new image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,4 +28,8 @@ updates:
     directory: "/tdd-platform"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/android-ci"
+    schedule:
+      interval: "weekly"
   

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Names of container images for their respective registries. (Space separated)
-  dockerhub: "esp-idf-qemu"
+  dockerhub: "esp-idf-qemu android-ci"
   github: "speki-ci tanks-ci vhdl_rpn-ci tdd-platform"
 
 jobs:

--- a/android-ci/Dockerfile
+++ b/android-ci/Dockerfile
@@ -1,0 +1,36 @@
+# Based on the excellent mingchen/docker-android-build-box:
+# https://github.com/mingchen/docker-android-build-box/blob/master/Dockerfile
+
+FROM ubuntu:impish
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+
+# Install Java JDK
+ENV JAVA_HOME="/usr/lib/jvm/java-18-openjdk-amd64"
+RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
+        git wget unzip \
+        openjdk-18-jdk \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+ENV PATH="$JAVA_HOME/bin:$PATH"
+
+# Install Android SDK manager
+ENV ANDROID_HOME="/opt/android-sdk"
+ARG ANDROID_SDK_TOOLS_VERSION=8512546
+RUN wget --quiet --output-document=sdk-tools.zip \
+        https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS_VERSION}_latest.zip \
+    && mkdir --parents "$ANDROID_HOME" \
+    && unzip -q sdk-tools.zip -d "$ANDROID_HOME/cmdline-tools" \
+    && mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest" \
+    && rm sdk-tools.zip
+ENV PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+
+# Accept SDK licenses and install android platform binaries and build tools.
+ENV ANDROID_PLATFORM_VERSION="android-32"
+ENV ANDROID_BUILD_TOOLS_VERSION="31.0.0"
+RUN mkdir --parents "$ANDROID_HOME/.android" \
+    && yes | sdkmanager --licenses > /dev/null \
+    && sdkmanager "platforms;${ANDROID_PLATFORM_VERSION}" \
+    && sdkmanager platform-tools \
+    && sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"


### PR DESCRIPTION
Add new container `android-ci` with pre installed Java 18 SDK and Android 12 SDK.