### PR TITLE
android-ci: create virtual avd device

### DIFF
--- a/android-ci/Dockerfile
+++ b/android-ci/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir --parents "$ANDROID_HOME/.android" \
 # Install and create an emulated virtual android smartphone.
 ENV PATH="$ANDROID_HOME/emulator:$PATH"
 RUN sdkmanager emulator \
-    && emulator-check \
+    && emulator-check accel \
     && sdkmanager "system-images;${ANDROID_BUILD_TOOLS_VERSION};google_apis;x86_64" \
     && echo "no" | avdmanager create avd --force --name ciAVD \
         --abi google_apis/x86_64 \

--- a/android-ci/Dockerfile
+++ b/android-ci/Dockerfile
@@ -27,10 +27,18 @@ RUN wget --quiet --output-document=sdk-tools.zip \
 ENV PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
 
 # Accept SDK licenses and install android platform binaries and build tools.
-ENV ANDROID_PLATFORM_VERSION="android-32"
-ENV ANDROID_BUILD_TOOLS_VERSION="31.0.0"
+ARG ANDROID_PLATFORM_VERSION="android-32"
+ARG ANDROID_BUILD_TOOLS_VERSION="31.0.0"
 RUN mkdir --parents "$ANDROID_HOME/.android" \
     && yes | sdkmanager --licenses > /dev/null \
     && sdkmanager "platforms;${ANDROID_PLATFORM_VERSION}" \
     && sdkmanager platform-tools \
     && sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
+
+# Install and create an virtual android smartphone.
+ENV PATH="$ANDROID_HOME/emulator:$PATH"
+RUN emulator-check \
+    && sdkmanager "system-images;${ANDROID_BUILD_TOOLS_VERSION};google_apis;x86_64" \
+    && echo "no" | avdmanager create avd --force --name ciAVD \
+        --abi google_apis/x86_64 \
+        --package "system-images;${ANDROID_BUILD_TOOLS_VERSION};google_apis;x86_64"

--- a/android-ci/Dockerfile
+++ b/android-ci/Dockerfile
@@ -35,9 +35,10 @@ RUN mkdir --parents "$ANDROID_HOME/.android" \
     && sdkmanager platform-tools \
     && sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
 
-# Install and create an virtual android smartphone.
+# Install and create an emulated virtual android smartphone.
 ENV PATH="$ANDROID_HOME/emulator:$PATH"
-RUN emulator-check \
+RUN sdkmanager emulator \
+    && emulator-check \
     && sdkmanager "system-images;${ANDROID_BUILD_TOOLS_VERSION};google_apis;x86_64" \
     && echo "no" | avdmanager create avd --force --name ciAVD \
         --abi google_apis/x86_64 \


### PR DESCRIPTION
This extends the Dockerfile and tries to create an virtual avd device to run `connectedAndroidTest` on. KVM needs to be enabled.

See:
https://stackoverflow.com/questions/42792947/how-to-create-android-virtual-device-with-command-line-and-avdmanager
https://stackoverflow.com/questions/20869067/run-android-emulator-without-gui-headless-android