### PR TITLE
zephyr-fuzz: add initial files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,4 +36,8 @@ updates:
     directory: "/zephyr-dev"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/zephyr-fuzz"
+    schedule:
+      interval: "weekly"
   

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
 env:
   # Names of container images for their respective registries. (Space separated)
   dockerhub: "esp-idf-qemu android-ci"
-  github: "speki-ci tanks-ci vhdl_rpn-ci tdd-platform zephyr-dev"
+  github: "speki-ci tanks-ci vhdl_rpn-ci tdd-platform zephyr-dev zephyr-fuzz"
 
 jobs:
 

--- a/zephyr-fuzz/Dockerfile
+++ b/zephyr-fuzz/Dockerfile
@@ -1,0 +1,32 @@
+FROM ghcr.io/nikleberg/zephyr-dev:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+
+# Install llvm toolchain
+RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
+        llvm \
+        clang \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+    
+# Install GraphFuzz for structure aware fuzzing
+ARG GFUZZ_CLONE_URL=https://github.com/NikLeberg/GraphFuzz.git
+ARG GFUZZ_CLONE_TAG=output_to_cerr
+RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
+        protobuf-compiler \
+        libprotobuf-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install poetry \
+    && cd /tmp \
+    && git clone $GFUZZ_CLONE_URL -b $GFUZZ_CLONE_TAG --depth 1 \
+    && cmake -S GraphFuzz -B GraphFuzz/build -DCMAKE_BUILD_TYPE=Release \
+    && make -C GraphFuzz/build install \
+    && cd ./GraphFuzz/cli \
+    && poetry build \
+    && poetry export > dist/requirements.txt \
+    && pip install -r dist/requirements.txt \
+    && pip install ./dist/gfuzz-*.whl \
+    && cd ../../ \
+    && rm -rf GraphFuzz

--- a/zephyr-fuzz/post_build.sh
+++ b/zephyr-fuzz/post_build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Execute whatever zephyr-dev defines as post build step.
+cd ../zephyr-dev
+./post_build.sh

--- a/zephyr-fuzz/pre_build.sh
+++ b/zephyr-fuzz/pre_build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Execute whatever zephyr-dev defines as pre build step.
+cd ../zephyr-dev
+./pre_build.sh
+
+# Disable security scanning, zephyr-dev is already scanned and this "overlay"
+# does not install many dependencies that could be checked automatically
+# anyways. Fingers crossed...
+echo "::set-output name=trivy_skip::skip"
+echo "::set-output name=dockle_skip::skip"


### PR DESCRIPTION
Add additional `zephyr-fuzz` image that builds on top of the already existing `zephyr-dev` image.
It's an extension to allow fuzzing zephyr i.e. install llvm/clang + fuzzers like graphfuzz.