### PR TITLE
quartus-prime: initial files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,4 +40,7 @@ updates:
     directory: "/zephyr-fuzz"
     schedule:
       interval: "weekly"
+    directory: "/quartus-prime"
+    schedule:
+      interval: "weekly"
   

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
 env:
   # Names of container images for their respective registries. (Space separated)
   dockerhub: "esp-idf-qemu android-ci"
-  github: "speki-ci tanks-ci vhdl_rpn-ci tdd-platform zephyr-dev zephyr-fuzz"
+  github: "speki-ci tanks-ci vhdl_rpn-ci tdd-platform zephyr-dev zephyr-fuzz quartus-prime"
 
 jobs:
 

--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -52,6 +52,7 @@ jobs:
         if: steps.pre_build.outputs.trivy_skip != 'skip'
         uses: aquasecurity/trivy-action@master
         with:
+          security-checks: vuln
           image-ref: ${{env.image_tag}}
           ignore-unfixed: true
           format: sarif

--- a/quartus-prime/Dockerfile
+++ b/quartus-prime/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir quartus-lite-linux \
     && rm -r $QUARTUS_ROOTDIR/uninstall \
     && rm -r $QUARTUS_ROOTDIR/logs \
     && rm -r $QUARTUS_ROOTDIR/nios2eds \
-    && rm -r $QUARTUS_ROOTDIR/ip \
+    && rm -r $QUARTUS_ROOTDIR/ip
 ENV PATH="$QUARTUS_ROOTDIR/quartus/bin:$QUARTUS_ROOTDIR/questa_fse/bin:${PATH}"
 
 # Install license aquired from https://licensing.intel.com/ that was fixed to a

--- a/quartus-prime/Dockerfile
+++ b/quartus-prime/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C
+
+# Update all packages and install neccessary tools and dependencies
+# https://yoloh3.github.io/linux/2016/12/24/install-modelsim-in-linux/
+RUN apt-get -q -y update \
+    && apt-get -q -y upgrade \
+    && apt-get -q -y install \
+        git wget \
+        libc6 libncurses6 libxtst6 libxft2 libstdc++6 libc6-dev lib32z1 \
+        libncurses5 libbz2-1.0 libpng16-16 libqt5xml5 liblzma-dev \
+        libcanberra-gtk-module \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Quartus Prime from:
+# https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html
+ARG QUARTUS_URL=https://downloads.intel.com/akdlm/software/acdsinst/21.1std.1/850/ib_tar/Quartus-lite-21.1.1.850-linux.tar
+ARG QUARTUS_SHA=789c1133d99fde7146fdb99c1f5dcb4d2e5cc0cc
+ARG QUARTUS_VERSION=21.1
+RUN mkdir quartus-lite-linux \
+    && cd quartus-lite-linux \
+    && wget --progress=dot:giga $QUARTUS_URL -O quartus.tar \
+    && echo "$QUARTUS_SHA *quartus.tar" | sha1sum --check --strict - \
+    && tar -xf quartus.tar \
+    && ./setup.sh \
+        --mode unattended --accept_eula 1 \
+        --installdir /opt/intelFPGA_lite/$QUARTUS_VERSION \
+        --disable-components arria_lite,cyclone10lp,max,max10 \
+    && cd .. \
+    && rm -r quartus-lite-linux
+ENV QUARTUS_ROOTDIR="/opt/intelFPGA_lite/$QUARTUS_VERSION"
+ENV PATH="$QUARTUS_ROOTDIR/quartus/bin:$QUARTUS_ROOTDIR/questa_fse/bin:${PATH}"
+
+# Install license aquired from https://licensing.intel.com/ that was fixed to a
+# manually crafted host / NIC / MAC id of 00:ab:ab:ab:ab:ab. To use this set the
+# mac address to use in the docker run command --mac-address="00:ab:ab:ab:ab:ab"
+COPY license.dat $QUARTUS_ROOTDIR/license/license.dat
+ENV LM_LICENSE_FILE=$QUARTUS_ROOTDIR/license/license.dat
+# Some documenting breadcrumbs:
+# flexlm allows for any host id that is displayed with the "lmhostid" tool. For
+# servers this could be the "real" hostid as in /etc/hostid. But with a server
+# based license a daemon needs to be running and also the hostname needs to be
+# fixed. So alternatively use the NIC based host id that is just the MAC addess.

--- a/quartus-prime/Dockerfile
+++ b/quartus-prime/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
-ENV LC_ALL=C
+ENV LC_ALL=C.UTF-8
+ENV LC_CTYPE=C.UTF-8
 
 # Update all packages and install neccessary tools and dependencies
 # https://yoloh3.github.io/linux/2016/12/24/install-modelsim-in-linux/
@@ -10,16 +11,17 @@ RUN apt-get -q -y update \
     && apt-get -q -y install \
         git wget \
         libc6 libncurses6 libxtst6 libxft2 libstdc++6 libc6-dev lib32z1 \
-        libncurses5 libbz2-1.0 libpng16-16 libqt5xml5 liblzma-dev \
-        libcanberra-gtk-module \
+        libncurses5 libbz2-1.0 libpng16-16 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+# libqt5xml5 liblzma-dev libcanberra-gtk-module
 
 # Install Quartus Prime from:
 # https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html
 ARG QUARTUS_URL=https://downloads.intel.com/akdlm/software/acdsinst/21.1std.1/850/ib_tar/Quartus-lite-21.1.1.850-linux.tar
 ARG QUARTUS_SHA=789c1133d99fde7146fdb99c1f5dcb4d2e5cc0cc
 ARG QUARTUS_VERSION=21.1
+ENV QUARTUS_ROOTDIR="/opt/intelFPGA_lite/$QUARTUS_VERSION"
 RUN mkdir quartus-lite-linux \
     && cd quartus-lite-linux \
     && wget --progress=dot:giga $QUARTUS_URL -O quartus.tar \
@@ -27,18 +29,21 @@ RUN mkdir quartus-lite-linux \
     && tar -xf quartus.tar \
     && ./setup.sh \
         --mode unattended --accept_eula 1 \
-        --installdir /opt/intelFPGA_lite/$QUARTUS_VERSION \
-        --disable-components arria_lite,cyclone10lp,max,max10 \
+        --installdir $QUARTUS_ROOTDIR \
+        --disable-components quartus_help,arria_lite,cyclone10lp,max,max10,quartus_update,questa_fe,modelsim_ase,modelsim_ae \
     && cd .. \
-    && rm -r quartus-lite-linux
-ENV QUARTUS_ROOTDIR="/opt/intelFPGA_lite/$QUARTUS_VERSION"
+    && rm -r quartus-lite-linux \
+    && rm -r $QUARTUS_ROOTDIR/uninstall \
+    && rm -r $QUARTUS_ROOTDIR/logs \
+    && rm -r $QUARTUS_ROOTDIR/nios2eds \
+    && rm -r $QUARTUS_ROOTDIR/ip \
 ENV PATH="$QUARTUS_ROOTDIR/quartus/bin:$QUARTUS_ROOTDIR/questa_fse/bin:${PATH}"
 
 # Install license aquired from https://licensing.intel.com/ that was fixed to a
 # manually crafted host / NIC / MAC id of 00:ab:ab:ab:ab:ab. To use this set the
-# mac address to use in the docker run command --mac-address="00:ab:ab:ab:ab:ab"
-COPY license.dat $QUARTUS_ROOTDIR/license/license.dat
-ENV LM_LICENSE_FILE=$QUARTUS_ROOTDIR/license/license.dat
+# mac address in the docker run command with --mac-address="00:ab:ab:ab:ab:ab"
+ENV LM_LICENSE_FILE=$QUARTUS_ROOTDIR/licenses/license.dat
+COPY license.dat $LM_LICENSE_FILE
 # Some documenting breadcrumbs:
 # flexlm allows for any host id that is displayed with the "lmhostid" tool. For
 # servers this could be the "real" hostid as in /etc/hostid. But with a server

--- a/quartus-prime/license.dat
+++ b/quartus-prime/license.dat
@@ -1,0 +1,27 @@
+﻿# Intel Corporation Software and/or Intellectual Property License File
+# Issued 10 October 2022
+# Upgrade to these products will no longer be available after the Maintenance Expiration  
+# date unless licenses are renewed.  
+# Fixed Node License
+# Primary Machine Name-docker-image3
+# Primary Machine ID-NIC ID 00ababababab
+# Companion ID-N/A
+# Companion ID 2-N/A
+# Product License Summary:
+# Questasim*-Intel® FPGA Starter Edition, 1 Seat(s)
+# - Maintenance Expiration of 2023.10
+# - License Expires 10-Oct-2023
+################################################################################ 
+# FEATURE START 
+# This is license file for Questasim*-Intel® FPGA Starter Edition 
+# Number of seat licenses is 1 
+# License Expires 10-Oct-2023 
+INCREMENT intelqsimstarter mgcld 2023.10 10-oct-2023 uncounted \
+  \
+    2F35127AB87AFC9A80AA VENDOR_STRING=993BF9DB HOSTID=00ababababab \
+    ISSUER=Intel SN=282509278 SIGN2="0196 3079 C2BB 2B9A 8CC1 8244 F216 \
+    E07B 9C82 5C3B 9D74 D1A4 3B5A 636B 4D88 03C3 EB8E 0F17 A24B B532 7408 \
+    96DB 7E04 6E86 F537 1DFD C17D A71A 6861 FC83"
+# FEATURE END 
+################################################################################
+# End of Intel Corporation Software and/or Intellectual Property License File. Issued 10/10/2022

--- a/quartus-prime/pre_build.sh
+++ b/quartus-prime/pre_build.sh
@@ -2,3 +2,6 @@
 
 # https://stackoverflow.com/questions/51903877/docker-load-no-space-left-on-device-rhel
 docker system prune -a -f --volumes
+
+# Skip Trivy scan step, image needs too much disk space.
+echo "::set-output name=trivy_skip::skip"

--- a/quartus-prime/pre_build.sh
+++ b/quartus-prime/pre_build.sh
@@ -3,5 +3,6 @@
 # https://stackoverflow.com/questions/51903877/docker-load-no-space-left-on-device-rhel
 docker system prune -a -f --volumes
 
-# Skip Trivy scan step, image needs too much disk space.
+# Skip Trivy and Dockle scan steps, image needs too much disk space.
 echo "::set-output name=trivy_skip::skip"
+echo "::set-output name=dockle_skip::skip"

--- a/quartus-prime/pre_build.sh
+++ b/quartus-prime/pre_build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# https://stackoverflow.com/questions/51903877/docker-load-no-space-left-on-device-rhel
+docker system prune -a -f --volumes


### PR DESCRIPTION
Add new container `quartus-prime` meant a a replacement of the `vhdl_rpn-ci` container.
It has a preinstalled Intel Quartus Prime v21.1 with installed Cyclone V device and Questasim (drop-in replacement of ModelSim). The licensing requirements of Questasim were a bit mad to virtualize. It may not be allowed to provide such a pre-licensed image.