### PR TITLE
tdd-platform: change to master gfuzz repo

### DIFF
--- a/tdd-platform/Dockerfile
+++ b/tdd-platform/Dockerfile
@@ -102,8 +102,8 @@ RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
     && pip install wllvm tabulate
 
 # Install packages for GraphFuzz structure aware fuzzing.
-ARG GFUZZ_CLONE_URL=https://github.com/NikLeberg/GraphFuzz.git
-ARG GFUZZ_CLONE_TAG=output_to_cerr
+ARG GFUZZ_CLONE_URL=https://github.com/hgarrereyn/GraphFuzz.git
+ARG GFUZZ_CLONE_TAG=master
 
 RUN pip install poetry \
     && cd /tmp \


### PR DESCRIPTION
Our pull request was merged. We can now switch back to the master
repository of hgarrereyn.
[informal output to cerr](https://github.com/hgarrereyn/GraphFuzz/pull/9)