### PR TITLE
neorv32_soc: add new image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,4 +46,7 @@ updates:
     directory: "/quartus-prime-aji"
     schedule:
       interval: "weekly"
+    directory: "/neorv32_soc"
+    schedule:
+      interval: "weekly"
   

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ env:
     zephyr-fuzz
     quartus-prime
     quartus-prime-aji
+    neorv32_soc
 
 jobs:
 

--- a/neorv32_soc/Dockerfile
+++ b/neorv32_soc/Dockerfile
@@ -1,0 +1,33 @@
+FROM ghcr.io/nikleberg/quartus-prime-aji:latest
+
+# Install neccessary tools and dependencies.
+RUN apt-get -q -y update \
+    && apt-get -q -y install \
+        git wget \
+        make gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* 
+
+# Install precompiled risc-v cross compiler toolchain.
+ARG RISCV_TOOLCHAIN_URL=https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv64imc-3.0.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
+ARG RISCV_TOOLCHAIN_SHA=8f3ea0f821feaaf664a442cd7e2871b1b1b3ace1
+ARG RISCV_TOOLCHAIN_PATH=/opt/riscv
+RUN wget --progress=dot:giga $RISCV_TOOLCHAIN_URL -O toolchain.tar.gz \
+    && echo "$RISCV_TOOLCHAIN_SHA *toolchain.tar.gz" | sha1sum --check --strict - \
+    && mkdir -p $RISCV_TOOLCHAIN_PATH \
+    && tar -xzf toolchain.tar.gz -C $RISCV_TOOLCHAIN_PATH \
+    && rm toolchain.tar.gz
+ENV PATH="$RISCV_TOOLCHAIN_PATH/bin:${PATH}"
+
+# GDB was compiled with support for python debugging, but in the version 3.8.
+# Available python version from apt is only the newer 3.10. Install that one and
+# create a symlink from "libpython3.10.so.1.0" to "libpython3.8.so.1.0" to allow
+# gdb to start i.e. the dynamic library to be loaded at startup. This probably
+# breaks python support within gdb, be cautious.
+RUN apt-get -q -y update \
+    && apt-get -q -y install libpython3.10 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s \
+        /usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0 \
+        /usr/lib/x86_64-linux-gnu/libpython3.8.so.1.0

--- a/neorv32_soc/pre_build.sh
+++ b/neorv32_soc/pre_build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# https://stackoverflow.com/questions/51903877/docker-load-no-space-left-on-device-rhel
+docker system prune -a -f --volumes
+
+# Skip Trivy and Dockle scan steps, image needs too much disk space.
+echo "trivy_skip=skip" >> $GITHUB_OUTPUT
+echo "dockle_skip=skip" >> $GITHUB_OUTPUT


### PR DESCRIPTION
New prebuild container for the excellent [`neorv32`](https://github.com/stnolting/neorv32) projekt. It extends the `quartus-prime-aji` image with a [prebuild risc-v compiler toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain).