### PR TITLE
quartus-prime: add pre_build dockerfile

### DIFF
--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -34,6 +34,21 @@ jobs:
       image_tag: ${{inputs.registry}}/${{inputs.username}}/${{matrix.image}}:latest
     steps:
 
+      - name: Maximize Build Space
+        working-directory: .
+        run: |
+          echo "Available storage (pre cleanup):"
+          df -h
+          echo
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/swift
+          echo "Available storage (after cleanup):"
+          df -h
+
       - name: Checkout Repository
         uses: actions/checkout@v3
 

--- a/quartus-prime/Dockerfile
+++ b/quartus-prime/Dockerfile
@@ -1,41 +1,38 @@
-FROM ubuntu:jammy
+FROM scratch
+
+# Quartus Prime is rather big and installing it in one run command would create
+# a huge image layer. A pre-build step does that and splits the layer up into
+# smaller chunks/tars. These can then be added one by one which results in
+# smaller layers. the imag eremains large but can be more easily pulled.
+ADD 0.tar /
+ADD 1.tar /
+ADD 2.tar /
+ADD 3.tar /
+ADD 4.tar /
+ADD 5.tar /
+ADD 6.tar /
+ADD 7.tar /
+ADD 8.tar /
+ADD 9.tar /
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8
 ENV LC_CTYPE=C.UTF-8
 
-# Update all packages and install neccessary tools and dependencies
+# Install necessary tools and dependencies
 # https://yoloh3.github.io/linux/2016/12/24/install-modelsim-in-linux/
 RUN apt-get -q -y update \
     && apt-get -q -y upgrade \
     && apt-get -q -y install \
-        git wget \
+        git \
         libncurses6 libxtst6 libxft2 libstdc++6 libc6-dev lib32z1 libbz2-1.0 \
         libpng16-16 libqt5xml5 libx11-xcb1 libsm6 libdbus-1-3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Quartus Prime from:
-# https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html
-ARG QUARTUS_URL=https://downloads.intel.com/akdlm/software/acdsinst/21.1std.1/850/ib_tar/Quartus-lite-21.1.1.850-linux.tar
-ARG QUARTUS_SHA=789c1133d99fde7146fdb99c1f5dcb4d2e5cc0cc
+# Add Quartus and Questa to path
 ARG QUARTUS_VERSION=21.1
 ENV QUARTUS_ROOTDIR="/opt/intelFPGA_lite/$QUARTUS_VERSION"
-RUN mkdir quartus-lite-linux \
-    && cd quartus-lite-linux \
-    && wget --progress=dot:giga $QUARTUS_URL -O quartus.tar \
-    && echo "$QUARTUS_SHA *quartus.tar" | sha1sum --check --strict - \
-    && tar -xf quartus.tar \
-    && ./setup.sh \
-        --mode unattended --accept_eula 1 \
-        --installdir $QUARTUS_ROOTDIR \
-        --disable-components quartus_help,quartus_update,questa_fe,modelsim_ase,modelsim_ae \
-    && cd .. \
-    && rm -r quartus-lite-linux \
-    && rm -r $QUARTUS_ROOTDIR/uninstall \
-    && rm -r $QUARTUS_ROOTDIR/logs \
-    && rm -r $QUARTUS_ROOTDIR/nios2eds \
-    && rm -r $QUARTUS_ROOTDIR/ip
 ENV PATH="$QUARTUS_ROOTDIR/quartus/bin:$QUARTUS_ROOTDIR/questa_fse/bin:${PATH}"
 
 # Install license aquired from https://licensing.intel.com/ that was fixed to a
@@ -48,3 +45,11 @@ COPY license.dat $LM_LICENSE_FILE
 # servers this could be the "real" hostid as in /etc/hostid. But with a server
 # based license a daemon needs to be running and also the hostname needs to be
 # fixed. So alternatively use the NIC based host id that is just the MAC addess.
+
+# Quartus asks at first startup if we have a license. We can skip this by
+# creating a specific file that quartus expects. What exactly the content is..
+# no clue. It changes everytime quartus is started for the first time. The
+# following values were observed: 47b262d9285cf37e, b3b88ae373d98a4f,
+# 5aa8417559ca6424, bfa7fb05de703e01, f7fcb7797c7d8b54.
+RUN mkdir ~/.altera.quartus \
+    && echo -n "5aa8417559ca6424">.dPwdoBmbMGe

--- a/quartus-prime/README.md
+++ b/quartus-prime/README.md
@@ -16,6 +16,8 @@ To reduce the size some per default installed parts were removed:
 * Intel / Altera IP blocks
 * Nios II EDS
 
+But even with these removed, the image is still very big (> 6 GB). The large _Quartus install_ image layer is split up into multiple smaller layers to help speed up image pull / download and make it more robust.
+
 ## Usage
 Generally the container can just be used with:
 ```shell
@@ -30,7 +32,7 @@ To use the Quartus or QuestaSim with a GUI, forward your X11 `DISPLAY` environme
 ```shell
 docker run -e DISPLAY ghcr.io/nikleberg/quartus-prime
 ```
-If you are running in _WSL2_ see this [blog post](https://aalonso.dev/blog/how-to-use-gui-apps-in-wsl2-forwarding-x-server-cdj) on how to setup `VcXsrc` as X11 Server on the Windows Host.
+If you are running in _WSL2_ see this [blog post](https://aalonso.dev/blog/how-to-use-gui-apps-in-wsl2-forwarding-x-server-cdj) on how to setup `VcXsrc` as X11 Server on the Windows Host. This allows you to access the X11 server from WSL. To further forward this to the docker container you can use the following argument when starting the container: `-e DISPLAY=host.docker.internal:0.0`. This special host name only works when the docker host is the _Docker Desktop for Windows_ application.
 
 ### Questasim License
 Since v21.1 of Quartus, ModelSim was replaced by QuestaSim. It requires a valid license that can be obtained from [intel](https://licensing.intel.com/). For ease of use a valid license is already included. But it is bound to a specific NIC id e.g. MAC address `00:ab:ab:ab:ab:ab`. Depending on where you want to use the container you have to set the MAC address differently:

--- a/quartus-prime/post_build.sh
+++ b/quartus-prime/post_build.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Clean up files from pre_build.sh.
+rm *.tar
+
 # We need to set the container MAC address while building the tests.dockerfile.
 # For this we start a dummy alpine container with the needed MAC address and
 # then build the test container with the network of that dummy container

--- a/quartus-prime/post_build.sh
+++ b/quartus-prime/post_build.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Fail on nonzero return
+set -e
+
 # Clean up files from pre_build.sh.
 rm *.tar
 

--- a/quartus-prime/pre_build.dockerfile
+++ b/quartus-prime/pre_build.dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+ENV LC_CTYPE=C.UTF-8
+
+# Install wget so we can download quartus installer.
+RUN apt-get -q -y update \
+    && apt-get -q -y install wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Quartus Prime from:
+# https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html
+ARG QUARTUS_URL=https://downloads.intel.com/akdlm/software/acdsinst/21.1std.1/850/ib_tar/Quartus-lite-21.1.1.850-linux.tar
+ARG QUARTUS_SHA=789c1133d99fde7146fdb99c1f5dcb4d2e5cc0cc
+ARG QUARTUS_VERSION=21.1
+ENV QUARTUS_ROOTDIR="/opt/intelFPGA_lite/$QUARTUS_VERSION"
+RUN mkdir quartus-lite-linux \
+    && cd quartus-lite-linux \
+    && wget --progress=dot:giga $QUARTUS_URL -O quartus.tar \
+    && echo "$QUARTUS_SHA *quartus.tar" | sha1sum --check --strict - \
+    && tar -xf quartus.tar \
+    && ./setup.sh \
+        --mode unattended --accept_eula 1 \
+        --installdir $QUARTUS_ROOTDIR \
+        --disable-components quartus_help,quartus_update,questa_fe,modelsim_ase,modelsim_ae \
+    && cd .. \
+    && rm -r quartus-lite-linux \
+    && rm -r $QUARTUS_ROOTDIR/uninstall \
+    && rm -r $QUARTUS_ROOTDIR/logs \
+    && rm -r $QUARTUS_ROOTDIR/nios2eds \
+    && rm -r $QUARTUS_ROOTDIR/ip

--- a/quartus-prime/pre_build.sh
+++ b/quartus-prime/pre_build.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Fail on nonzero return
+set -e
+
 # https://stackoverflow.com/questions/51903877/docker-load-no-space-left-on-device-rhel
 docker system prune -a -f --volumes
 

--- a/quartus-prime/pre_build.sh
+++ b/quartus-prime/pre_build.sh
@@ -6,3 +6,30 @@ docker system prune -a -f --volumes
 # Skip Trivy and Dockle scan steps, image needs too much disk space.
 echo "trivy_skip=skip" >> $GITHUB_OUTPUT
 echo "dockle_skip=skip" >> $GITHUB_OUTPUT
+
+# This docker image gets rather big as it needs to download Quartus with a hefty
+# size of more than 6 GB. This would create a single layer in the image with a
+# huge size and that has to be downloaded and can't be parrelelized. To break
+# this layer up, a few steps are performed here in this script that is run
+# before the main image is built:
+#  - Download / Extract / Install Quartus in a separate docker container.
+#  - Run the image as container so that the `docker export` command works.
+#  - Export the content of that dockerfile to a tar.
+#  - Split the tar as file boundaries into multiple tars.
+#  - The split tars can be imported with multiple layers on the real Dockerfile.
+
+# Build pre_build dockerfile and export its filesystem as tar.
+docker build -t ghcr.io/nikleberg/quartus-prime_pre-build -f pre_build.dockerfile .
+docker create --name quartus-prime_pre-build ghcr.io/nikleberg/quartus-prime_pre-build
+docker export quartus-prime_pre-build -o quartus-prime_pre-build.tar
+docker rm quartus-prime_pre-build
+
+# Split tar into smaller chunks at file boundaries.
+TAR_SPLITTER_URL=https://github.com/AQUAOSOTech/tarsplitter/releases/download/v2.2.0/tarsplitter_linux
+TAR_SPLITTER_SHA=d92d19b36f03eadd25e9ee17d659761a0788b2e5
+wget --progress=dot $TAR_SPLITTER_URL -O tarsplitter
+echo "$TAR_SPLITTER_SHA *tarsplitter" | sha1sum --check --strict -
+chmod +x tarsplitter
+./tarsplitter -i quartus-prime_pre-build.tar -p 10
+rm quartus-prime_pre-build.tar
+rm tarsplitter


### PR DESCRIPTION
This aims to break up the large _Quartus install_ layer into multiple smaller layers.

When pulling with `docker pull` each image layer is pulled one by one. If one of the layer fails to download or the download is interrupted, docker restarts to download from the beginning. As a layer of ~ 6 GB is annoying to download multiple times, breaking it up into smaller (< 1 GB) layers should help in that regard.