### PR TITLE
quartus-prime: update to v22.1

### DIFF
--- a/quartus-prime/Dockerfile
+++ b/quartus-prime/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -q -y update \
     && rm -rf /var/lib/apt/lists/*
 
 # Add Quartus and Questa to path
-ARG QUARTUS_VERSION=21.1
+ARG QUARTUS_VERSION=22.1
 ENV QUARTUS_ROOTDIR="/opt/intelFPGA_lite/$QUARTUS_VERSION"
 ENV PATH="$QUARTUS_ROOTDIR/quartus/bin:$QUARTUS_ROOTDIR/questa_fse/bin:${PATH}"
 

--- a/quartus-prime/pre_build.dockerfile
+++ b/quartus-prime/pre_build.dockerfile
@@ -12,9 +12,9 @@ RUN apt-get -q -y update \
 
 # Install Quartus Prime from:
 # https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html
-ARG QUARTUS_URL=https://downloads.intel.com/akdlm/software/acdsinst/21.1std.1/850/ib_tar/Quartus-lite-21.1.1.850-linux.tar
-ARG QUARTUS_SHA=789c1133d99fde7146fdb99c1f5dcb4d2e5cc0cc
-ARG QUARTUS_VERSION=21.1
+ARG QUARTUS_URL=https://downloads.intel.com/akdlm/software/acdsinst/22.1std/915/ib_tar/Quartus-lite-22.1std.0.915-linux.tar
+ARG QUARTUS_SHA=9eeb9ce158348e34614e69873af15de223e786d8
+ARG QUARTUS_VERSION=22.1
 ENV QUARTUS_ROOTDIR="/opt/intelFPGA_lite/$QUARTUS_VERSION"
 RUN mkdir quartus-lite-linux \
     && cd quartus-lite-linux \

--- a/quartus-prime/pre_build.dockerfile
+++ b/quartus-prime/pre_build.dockerfile
@@ -24,7 +24,7 @@ RUN mkdir quartus-lite-linux \
     && ./setup.sh \
         --mode unattended --accept_eula 1 \
         --installdir $QUARTUS_ROOTDIR \
-        --disable-components quartus_help,quartus_update,questa_fe,modelsim_ase,modelsim_ae \
+        --disable-components quartus_help,quartus_update,questa_fe \
     && cd .. \
     && rm -r quartus-lite-linux \
     && rm -r $QUARTUS_ROOTDIR/uninstall \


### PR DESCRIPTION
This updates the quartus prime installation to v22.1 acquired from the official [intel website](https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html).