### PR TITLE
ci: add possibility of crude dependency management

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,34 +8,35 @@ on:
   workflow_dispatch:
 
 env:
-  # Names of container images for their respective registries.
-  dockerhub:
+  # Names of container images to build that have no repository internal
+  # dependencies.
+  stage_1:
     esp-idf-qemu
     android-ci
-  github: 
     speki-ci
     tanks-ci
     vhdl_rpn-ci
     tdd-platform
     zephyr-dev
-    zephyr-fuzz
     quartus-prime
+  # Names of images that depend on others in stage 1.
+  stage_2:
+    zephyr-fuzz
     quartus-prime-aji
+  # Names of images that depend on others in stage 2.
+  stage_3:
     neorv32_soc
 
 jobs:
 
   detect_changes:
     name: Detect Changes
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
+    runs-on: ubuntu-22.04
     outputs:
-      dockerhub-changed: ${{steps.changed-containers.outputs.dockerhub-changed}}
-      github-changed: ${{steps.changed-containers.outputs.github-changed}}
+      stage_1: ${{steps.changed-containers.outputs.stage_1}}
+      stage_2: ${{steps.changed-containers.outputs.stage_2}}
+      stage_3: ${{steps.changed-containers.outputs.stage_3}}
     steps:
-
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
@@ -43,30 +44,44 @@ jobs:
 
       - name: Detect changed Containers
         id: changed-containers
-        run: .github/workflows/detect_changes.sh "${{env.dockerhub}}" "${{env.github}}"
+        run: .github/workflows/detect_changes.sh "${{env.stage_1}}" "${{env.stage_2}}" "${{env.stage_3}}"
+        shell: bash
 
-  dockerhub:
-    name: DockerHub
+  stage_1:
+    name: Build Stage 1 Images
     needs: detect_changes
-    if: needs.detect_changes.outputs.dockerhub-changed != ''
-    uses: ./.github/workflows/container_builder.yml
-    with:
-      registry: docker.io
-      username: nikolodion
-      images: ${{needs.detect_changes.outputs.dockerhub-changed}}
-      push: ${{github.ref_name == 'main'}}
-    secrets:
-      password: ${{secrets.DOCKERHUB_PASSWORD}}
-
-  github:
-    name: GitHub registry
-    needs: detect_changes
-    if: needs.detect_changes.outputs.github-changed != ''
+    if: needs.detect_changes.outputs.stage_1 != ''
     uses: ./.github/workflows/container_builder.yml
     with:
       registry: ghcr.io
       username: nikleberg
-      images: ${{needs.detect_changes.outputs.github-changed}}
+      images: ${{needs.detect_changes.outputs.stage_1}}
+      push: ${{github.ref_name == 'main'}}
+    secrets:
+      password: ${{secrets.GITHUB_TOKEN}}
+
+  stage_2:
+    name: Build Stage 2 Images
+    needs: [detect_changes, stage_1]
+    if: needs.detect_changes.outputs.stage_2 != ''
+    uses: ./.github/workflows/container_builder.yml
+    with:
+      registry: ghcr.io
+      username: nikleberg
+      images: ${{needs.detect_changes.outputs.stage_2}}
+      push: ${{github.ref_name == 'main'}}
+    secrets:
+      password: ${{secrets.GITHUB_TOKEN}}
+
+  stage_3:
+    name: Build Stage 3 Images
+    needs: [detect_changes, stage_2]
+    if: needs.detect_changes.outputs.stage_3 != ''
+    uses: ./.github/workflows/container_builder.yml
+    with:
+      registry: ghcr.io
+      username: nikleberg
+      images: ${{needs.detect_changes.outputs.stage_3}}
       push: ${{github.ref_name == 'main'}}
     secrets:
       password: ${{secrets.GITHUB_TOKEN}}
@@ -76,11 +91,8 @@ jobs:
     # and expecially all its 'needs' succeeded.
     # See: https://github.com/actions/runner/issues/491
     name: Summarize
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
-    needs: [dockerhub, github]
+    runs-on: ubuntu-22.04
+    needs: [stage_1, stage_2, stage_3]
     if: always()
     steps:
       - name: Successful builds?
@@ -93,3 +105,4 @@ jobs:
             echo "One or more matrix builds were cancelled!"
             false
           fi
+        shell: bash

--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +31,7 @@ jobs:
         shell: bash
         working-directory: ./${{matrix.image}}
     env:
-      image_tag: ${{inputs.registry}}/${{inputs.username}}/${{matrix.image}}:latest
+      base_tag: ${{inputs.registry}}/${{inputs.username}}/${{matrix.image}}
     steps:
 
       - name: Maximize Build Space
@@ -59,16 +59,16 @@ jobs:
           then
             ./pre_build.sh
           fi
-        
+
       - name: Build Container
-        run: docker build --pull -t ${{env.image_tag}} .
+        run: docker build --pull -t ${{env.base_tag}}:staging .
 
       - name: Scan Container with Trivy
         if: steps.pre_build.outputs.trivy_skip != 'skip'
         uses: aquasecurity/trivy-action@master
         with:
           security-checks: vuln
-          image-ref: ${{env.image_tag}}
+          image-ref: ${{env.base_tag}}:staging
           ignore-unfixed: true
           format: sarif
           output: trivy-results.sarif
@@ -76,30 +76,37 @@ jobs:
 
       - name: Scan Container with Dockle
         if: steps.pre_build.outputs.dockle_skip != 'skip'
-        uses: erzz/dockle-action@v1.3.1
+        uses: erzz/dockle-action@v1.3.2
         with:
-          image: ${{env.image_tag}}
+          image: ${{env.base_tag}}:staging
           failure-threshold: FATAL
           exit-code: 1
           timeout: 20m
-          dockle-version: "0.4.5"
 
       - name: Upload Scan Results
         if: steps.pre_build.outputs.trivy_skip != 'skip'
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: .
-        
+
       - name: Run post_build Script
         run: |
           if [ -e ./post_build.sh ]
           then
             ./post_build.sh
           fi
-        
-      - name: Push Container
-        if: inputs.push
+
+      - name: Login to Registry
         run: |
           echo ${{secrets.password}} | docker login ${{inputs.registry}} -u ${{inputs.username}} --password-stdin
-          docker push ${{env.image_tag}}
-          docker logout ${{inputs.registry}}
+
+      - name: Push Container as Staging
+        run: docker push ${{env.base_tag}}:staging
+
+      - name: Push Container as Latest
+        if: inputs.push
+        run: docker push ${{env.base_tag}}:latest
+
+      - name: Logout from Registry
+        if: always()
+        run: docker logout ${{inputs.registry}}

--- a/.github/workflows/detect_changes.sh
+++ b/.github/workflows/detect_changes.sh
@@ -29,37 +29,51 @@ for container in */; do
 done
 
 # From the detected containers, compare them with the given lists of containers
-# of each registry. This then builds two JSON arrays that hold the containers of
-# each registry that needs to be updated.
-dockerhub=$1
-github=$2
-changed_dockerhub="["
-changed_github="["
+# of each stage. This then builds three JSON arrays that hold the containers of
+# each stage that needs to be updated.
+stage_1=$1
+stage_2=$2
+stage_3=$3
+changed_stage_1="["
+changed_stage_2="["
+changed_stage_3="["
 for container in ${changed_containers[@]}; do
-    for d_container in $dockerhub; do
+    for d_container in $stage_1; do
         if [ "$d_container" == "$container" ]; then
-            changed_dockerhub+="\"$container\","
+            changed_stage_1+="\"$container\","
         fi
     done
-    for g_container in ${github[@]}; do
-        if [ "$g_container" == "$container" ]; then
-            changed_github+="\"$container\","
+    for d_container in $stage_2; do
+        if [ "$d_container" == "$container" ]; then
+            changed_stage_2+="\"$container\","
+        fi
+    done
+    for d_container in $stage_3; do
+        if [ "$d_container" == "$container" ]; then
+            changed_stage_3+="\"$container\","
         fi
     done
 done
-if [ "$changed_dockerhub" == "[" ]; then
-    changed_dockerhub=""
+if [ "$changed_stage_1" == "[" ]; then
+    changed_stage_1=""
 else
-    changed_dockerhub="${changed_dockerhub::-1}]"
+    changed_stage_1="${changed_stage_1::-1}]"
 fi
-if [ "$changed_github" == "[" ]; then
-    changed_github=""
+if [ "$changed_stage_2" == "[" ]; then
+    changed_stage_2=""
 else
-    changed_github="${changed_github::-1}]"
+    changed_stage_2="${changed_stage_2::-1}]"
 fi
-echo "Containers from DockerHub that need to be updated: $changed_dockerhub"
-echo "Containers from GitHub registry that need to be updated: $changed_github"
+if [ "$changed_stage_3" == "[" ]; then
+    changed_stage_3=""
+else
+    changed_stage_3="${changed_stage_3::-1}]"
+fi
+echo "Containers from stage 1 that need to be updated: $changed_stage_1"
+echo "Containers from stage 2 that need to be updated: $changed_stage_2"
+echo "Containers from stage 3 that need to be updated: $changed_stage_3"
 
 # Set step output for GitHub Action.
-echo "dockerhub-changed=$changed_dockerhub" >> $GITHUB_OUTPUT
-echo "github-changed=$changed_github" >> $GITHUB_OUTPUT
+echo "stage_1=$changed_stage_1" >> $GITHUB_OUTPUT
+echo "stage_2=$changed_stage_2" >> $GITHUB_OUTPUT
+echo "stage_3=$changed_stage_3" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # container_builder
-This project uses the GitHub Actions CI to automatically build and push container images to [dockerhub](https://hub.docker.com/) and the GitHub registry. The main goal of this is to prebuild CI images for other projects. Otherwise the CI of those projects would need to rebuild the image every time on its own. With this it can just download the prebuilt image.
+This project uses the GitHub Actions CI to automatically build and push container images to the [GitHub registry](ghcr.io). The main goal of this is to prebuild CI images for other projects. Otherwise the CI of those projects would need to rebuild the image every time on its own. With this it can just download the prebuilt image.
 
 ## Usage
-dockerhub:
-- `docker pull nikolodion/<image_name>`
-
 GitHub registry:
 - `docker pull ghcr.io/nikleberg/<image_name>`
 
@@ -12,6 +9,10 @@ For specific usage of each image please have a look at the corresponding `README
 
 ## Adding images
 To build the different images, [matrix builds](https://docs.github.com/en/actions/using-jobs/using-a-build-matrix-for-your-jobs) in [CI.yml](.github/workflows/CI.yml) are defined. Additional images can be added by extending the toplevel `env` variable with the image name. In a subfolder of the same name place the coresponding Dockerfile. Optionally one can add `pre_build.sh` and `post_build.sh` scripts that will be run before and after the image is build. This allows for example to download support files, disabling Trivy/Dockle scanner steps or running tests against the image.
+Three stages exists that run one after the other to allow for dependencies between repository internal images.
+
+## Tags
+During build of images (i.e. in pull requests) the tag `staging` is pushed. If the build is successful, then the same image will be released with `latest` tag. Images that depend on previous repository internal images shall use the `staging` tag.
 
 ## License
 [MIT](LICENSE) © [NikLeberg](https://github.com/NikLeberg).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ For specific usage of each image please have a look at the corresponding `README
 
 ## Adding images
 To build the different images, [matrix builds](https://docs.github.com/en/actions/using-jobs/using-a-build-matrix-for-your-jobs) in [CI.yml](.github/workflows/CI.yml) are defined. Additional images can be added by extending the toplevel `env` variable with the image name. In a subfolder of the same name place the coresponding Dockerfile. Optionally one can add `pre_build.sh` and `post_build.sh` scripts that will be run before and after the image is build. This allows for example to download support files, disabling Trivy/Dockle scanner steps or running tests against the image.
+
+### Dependency Resolution
 Three stages exists that run one after the other to allow for dependencies between repository internal images.
+If for example a new image `image_new` depends on `image_a`, then add the new image to the `env.stage_2` entry in [CI.yml](.github/workflows/CI.yml). This assumes the base image `image_a` was in `env.stage_1`.
+Additionally you must add a `depends.on` file to the image folder that contains a single line naming the base image, in the example this would be `image_a`. Otherwise the new image will not be rebuilt if the base image changes.
 
 ## Tags
 During build of images (i.e. in pull requests) the tag `staging` is pushed. If the build is successful, then the same image will be released with `latest` tag. Images that depend on previous repository internal images shall use the `staging` tag.

--- a/neorv32_soc/Dockerfile
+++ b/neorv32_soc/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/nikleberg/quartus-prime-aji:latest
+# Use staging tag to depend on just build image from previous CI stage. For
+# releases this is equivalent to latest tag.
+FROM ghcr.io/nikleberg/quartus-prime-aji:staging
 
 # Install neccessary tools and dependencies.
 RUN apt-get -q -y update \

--- a/neorv32_soc/depends.on
+++ b/neorv32_soc/depends.on
@@ -1,0 +1,1 @@
+quartus-prime-aji

--- a/quartus-prime-aji/Dockerfile
+++ b/quartus-prime-aji/Dockerfile
@@ -51,8 +51,10 @@ RUN git clone $AJI_OPENOCD_CLONE_URL -b $AJI_OPENOCD_CLONE_TAG --depth 1 \
     && sed -i 's/CCLD = \$(CC)/CCLD = g++/g' ./Makefile \
     && make
 
-# Import built openocd into quartus prime container.
-FROM ghcr.io/nikleberg/quartus-prime:latest
+# Import built openocd into quartus prime container. Use staging tag to depend
+# on just build image from previous CI stage. For releases this is equivalent to
+# latest tag.
+FROM ghcr.io/nikleberg/quartus-prime:staging
 COPY --from=openocd_builder /aji_openocd/src/openocd /opt/aji_openocd/
 COPY --from=openocd_builder /aji_openocd/tcl /opt/aji_openocd/tcl
 

--- a/quartus-prime-aji/depends.on
+++ b/quartus-prime-aji/depends.on
@@ -1,0 +1,1 @@
+quartus-prime

--- a/quartus-prime/tests.dockerfile
+++ b/quartus-prime/tests.dockerfile
@@ -1,5 +1,5 @@
 # Pull in the (probably) just built image and build an example design.
-FROM ghcr.io/nikleberg/quartus-prime:latest
+FROM ghcr.io/nikleberg/quartus-prime:staging
 
 ADD test_design.tar.bz2 /tmp/test_design
 RUN cd /tmp/test_design/geni/modelsim \

--- a/tdd-platform/tests.dockerfile
+++ b/tdd-platform/tests.dockerfile
@@ -1,6 +1,6 @@
 # Pull in the (probably) just built image, clone the tdd-platform project repo
 # and try to build for each platform.
-FROM ghcr.io/nikleberg/tdd-platform:latest
+FROM ghcr.io/nikleberg/tdd-platform:staging
 
 RUN git clone https://github.com/NikLeberg/tdd-platform.git --recurse-submodules \
     && cd tdd-platform \

--- a/zephyr-dev/tests.dockerfile
+++ b/zephyr-dev/tests.dockerfile
@@ -1,5 +1,5 @@
 # Pull in the (probably) just built image and build the hello_world example.
-FROM ghcr.io/nikleberg/zephyr-dev:latest
+FROM ghcr.io/nikleberg/zephyr-dev:staging
 
 RUN cd /opt/zephyrproject/zephyr \
     && west build -p auto -b native_posix samples/hello_world \

--- a/zephyr-fuzz/Dockerfile
+++ b/zephyr-fuzz/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nikleberg/zephyr-dev:latest
+FROM ghcr.io/nikleberg/zephyr-dev:staging
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8

--- a/zephyr-fuzz/depends.on
+++ b/zephyr-fuzz/depends.on
@@ -1,0 +1,1 @@
+zephyr-dev


### PR DESCRIPTION
This allows images to depend somewhat on eachother. For this the multi registry for _DockerHub_ and _Github Registry_ was removed: Only _GitHub Registry_ is used from now on. But then the CI has been extended to have three build stages and each build stage can have images that can depend on those of previous stages.

For example for the currently most complex image build `neorv32_soc` the build order is:
- `quartus-prime`
- `quartus-prime-aji`
- `neorv32_soc`

ToDo:
- [x] If base image has changed files, the dependent image is not rebuild automatically