### PR TITLE
ci: fix error "tag does not exist"

### DIFF
--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -105,7 +105,9 @@ jobs:
 
       - name: Push Container as Latest
         if: inputs.push
-        run: docker push ${{env.base_tag}}:latest
+        run: |
+          docker tag ${{env.base_tag}}:staging ${{env.base_tag}}:latest
+          docker push ${{env.base_tag}}:latest
 
       - name: Logout from Registry
         if: always()


### PR DESCRIPTION
Error in release step was not covered in CI tests. The `staging` tag could be pushed but `latest` was not existing. Add the tag first before pushing.