### PR TITLE
tdd-platform: test fork of GraphFuzz

### DIFF
--- a/tdd-platform/Dockerfile
+++ b/tdd-platform/Dockerfile
@@ -102,8 +102,8 @@ RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
     && pip install wllvm tabulate
 
 # Install packages for GraphFuzz structure aware fuzzing.
-ARG GFUZZ_CLONE_URL=https://github.com/hgarrereyn/GraphFuzz.git
-ARG GFUZZ_CLONE_TAG=master
+ARG GFUZZ_CLONE_URL=https://github.com/NikLeberg/GraphFuzz.git
+ARG GFUZZ_CLONE_TAG=fix/harness_running_twice
 
 RUN pip install poetry \
     && cd /tmp \


### PR DESCRIPTION
Only testing a fork of GraphFuzz with a fix. Not intended to merge to main, pr only exists so GitHub Actions run.