### PR TITLE
neorv32_soc: install cutecom for uart comm

### DIFF
--- a/neorv32_soc/Dockerfile
+++ b/neorv32_soc/Dockerfile
@@ -7,8 +7,9 @@ RUN apt-get -q -y update \
     && apt-get -q -y install \
         git wget \
         make gcc \
+        cutecom \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*
 
 # Install precompiled risc-v cross compiler toolchain.
 ARG RISCV_TOOLCHAIN_URL=https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv64imc-3.0.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz


### PR DESCRIPTION
Cutecom is used for the UART connection to the NEORV32 based SoC. Pre install it.