### PR TITLE
neorv32_soc: build own version of gcc with 'a' ext

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
   stage_1:
     name: Build Stage 1 Images
     needs: detect_changes
-    if: needs.detect_changes.outputs.stage_1 != ''
+    if: always() && needs.detect_changes.outputs.stage_1 != ''
     uses: ./.github/workflows/container_builder.yml
     with:
       registry: ghcr.io
@@ -63,7 +63,7 @@ jobs:
   stage_2:
     name: Build Stage 2 Images
     needs: [detect_changes, stage_1]
-    if: needs.detect_changes.outputs.stage_2 != ''
+    if: always() && needs.detect_changes.outputs.stage_2 != ''
     uses: ./.github/workflows/container_builder.yml
     with:
       registry: ghcr.io
@@ -76,7 +76,7 @@ jobs:
   stage_3:
     name: Build Stage 3 Images
     needs: [detect_changes, stage_2]
-    if: needs.detect_changes.outputs.stage_3 != ''
+    if: always() && needs.detect_changes.outputs.stage_3 != ''
     uses: ./.github/workflows/container_builder.yml
     with:
       registry: ghcr.io

--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -67,7 +67,7 @@ jobs:
         if: steps.pre_build.outputs.trivy_skip != 'skip'
         uses: aquasecurity/trivy-action@master
         with:
-          security-checks: vuln
+          scanners: vuln
           image-ref: ${{env.base_tag}}:staging
           ignore-unfixed: true
           format: sarif

--- a/neorv32_soc/Dockerfile
+++ b/neorv32_soc/Dockerfile
@@ -1,3 +1,32 @@
+# Build risc-v gcc compiler in separate docker builder.
+# Process as described in: https://github.com/riscv-collab/riscv-gnu-toolchain
+FROM ubuntu:jammy as riscv_gcc_builder
+
+# Install prerequisites.
+RUN apt-get -q -y update \
+    && apt-get -q -y install \
+        git autoconf automake autotools-dev curl python3 libmpc-dev \
+        libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf \
+        libtool patchutils bc zlib1g-dev libexpat-dev ninja-build \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Get the sources.
+ARG RISCV_GNU_CLONE_URL=https://github.com/riscv/riscv-gnu-toolchain
+ARG RISCV_GNU_CLONE_TAG=2023.04.21
+RUN git clone $RISCV_GNU_CLONE_URL -b $RISCV_GNU_CLONE_TAG --depth 1
+
+# Build with newlib cross-compiler
+ARG RISCV_TOOLCHAIN_PATH=/opt/riscv
+ARG RISCV_ARCH=rv32imac
+ARG RISCV_ABI=ilp32
+ENV PATH="$RISCV_TOOLCHAIN_PATH/bin:${PATH}"
+RUN cd riscv-gnu-toolchain \
+    && ./configure --prefix=/opt/riscv \
+        --with-arch=$RISCV_ARCH --with-abi=$RISCV_ABI \
+    && make
+
+
 # Use staging tag to depend on just build image from previous CI stage. For
 # releases this is equivalent to latest tag.
 FROM ghcr.io/nikleberg/quartus-prime-aji:staging
@@ -12,15 +41,10 @@ RUN apt-get -q -y update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install precompiled risc-v cross compiler toolchain.
-ARG RISCV_TOOLCHAIN_URL=https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv64imc-3.0.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
-ARG RISCV_TOOLCHAIN_SHA=8f3ea0f821feaaf664a442cd7e2871b1b1b3ace1
 ARG RISCV_TOOLCHAIN_PATH=/opt/riscv
-RUN wget --progress=dot:giga $RISCV_TOOLCHAIN_URL -O toolchain.tar.gz \
-    && echo "$RISCV_TOOLCHAIN_SHA *toolchain.tar.gz" | sha1sum --check --strict - \
-    && mkdir -p $RISCV_TOOLCHAIN_PATH \
-    && tar -xzf toolchain.tar.gz -C $RISCV_TOOLCHAIN_PATH \
-    && rm toolchain.tar.gz
+COPY --from=riscv_gcc_builder $RISCV_TOOLCHAIN_PATH $RISCV_TOOLCHAIN_PATH
 ENV PATH="$RISCV_TOOLCHAIN_PATH/bin:${PATH}"
+ENV RISCV_PREFIX=riscv32-unknown-elf-
 
 # GDB was compiled with support for python debugging, but in the version 3.8.
 # Available python version from apt is only the newer 3.10. Install that one and
@@ -28,6 +52,7 @@ ENV PATH="$RISCV_TOOLCHAIN_PATH/bin:${PATH}"
 # gdb to start i.e. the dynamic library to be loaded at startup. This probably
 # breaks python support within gdb, be cautious.
 RUN apt-get -q -y update \
+    && sed -i '/messagebus/d' /var/lib/dpkg/statoverride \
     && apt-get -q -y install libpython3.10 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/tdd-platform/Dockerfile
+++ b/tdd-platform/Dockerfile
@@ -61,8 +61,6 @@ ARG STP_CLONE_URL=https://github.com/stp/stp.git
 ARG STP_CLONE_TAG=2.3.3
 ARG KLEE_CLONE_URL=https://github.com/klee/klee.git
 ARG KLEE_CLONE_TAG=master
-ARG KLEE_CLONE_SHA=6268027
-ARG KLEE_PATCH_URL=https://github.com/klee/klee/pull/1477.patch
 
 RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
         zlib1g-dev \
@@ -86,11 +84,6 @@ RUN apt-get -q -y update && apt-get -q -y install --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && git clone $KLEE_CLONE_URL -b $KLEE_CLONE_TAG \
-    && cd klee \
-    && git checkout $KLEE_CLONE_SHA \
-    && wget $KLEE_PATCH_URL -O llvm-14.patch \
-    && git apply llvm-14.patch \
-    && cd .. \
     && CXXFLAGS="-w" cmake -S klee -B klee/build \
         -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_SOLVER_STP=ON \


### PR DESCRIPTION
Default prebuild gcc libraries from https://github.com/stnolting/riscv-gcc-prebuilt don't contain support for atomics extension. Build our own gcc.