### PR TITLE
quartus-prime: use buildx for post_buildx

### DIFF
--- a/quartus-prime/post_build.sh
+++ b/quartus-prime/post_build.sh
@@ -9,9 +9,7 @@ rm *.tar
 # We need to set the container MAC address while building the tests.dockerfile.
 # For this we start a dummy alpine container with the needed MAC address and
 # then build the test container with the network of that dummy container
-# attached to it. We have to disable buildkit though as it does not support the
-# network build option. Source: https://stackoverflow.com/a/48676884/16034014
-export DOCKER_BUILDKIT=0
+# attached to it. Source: https://stackoverflow.com/a/48676884/16034014
 docker run --name=mac00ababababab --mac-address=00:ab:ab:ab:ab:ab -d alpine tail -f /dev/null
 docker build --network=container:mac00ababababab -f tests.dockerfile .
 docker rm --force mac00ababababab


### PR DESCRIPTION
Previously `docker buildx` was not able to utilize the `--network` option. It seems that this is now possible. With the recent change to `buildx` this is required anyway as such the _old_ image in the registry is pulled and not the just built one.