### PR TITLE
questasim/new: new image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,4 +44,8 @@ updates:
     directory: "/dev-base"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/questasim"
+    schedule:
+      interval: "weekly"
   

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ env:
     tdd-platform
     quartus-prime
     dev-base
+    questasim
   # Names of images that depend on others in stage 1.
   stage_2:
     quartus-prime-aji

--- a/questasim/Dockerfile
+++ b/questasim/Dockerfile
@@ -1,0 +1,52 @@
+FROM scratch
+
+# Questa is rather big and installing it in one run command would create a huge
+# image layer. A pre-build step does that and splits the layer up into smaller
+# chunks/tars. These can then be added one by one which results in smaller
+# layers. The image remains large but can be more easily pulled.
+ADD 0.tar /
+ADD 1.tar /
+ADD 2.tar /
+ADD 3.tar /
+ADD 4.tar /
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    LC_CTYPE=C.UTF-8
+
+# Install necessary tools and dependencies
+# https://yoloh3.github.io/linux/2016/12/24/install-modelsim-in-linux/
+RUN <<EOF
+    set -e
+    apt-get -q -y update
+    apt-get -q -y upgrade
+    apt-get -q -y install --no-install-recommends \
+        libncurses6 libxtst6 libxft2 libstdc++6 libc6 lib32z1 libbz2-1.0 \
+        libpng16-16 libqt5xml5 libx11-xcb1 libsm6 libdbus-1-3
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Add Questa to path
+ARG QUESTA_VERSION=22.1.1
+ENV QUESTA_ROOTDIR="/opt/QuestaSim/$QUESTA_VERSION"
+ENV PATH="$QUESTA_ROOTDIR/questa_fse/bin:${PATH}"
+
+# Install license aquired from https://licensing.intel.com/ that was fixed to a
+# manually crafted host / NIC / MAC id of 00:ab:ab:ab:ab:ab. To use this set the
+# mac address in the docker run command with --mac-address="00:ab:ab:ab:ab:ab"
+ENV LM_LICENSE_FILE=$QUESTA_ROOTDIR/licenses/license.dat
+COPY license.dat $LM_LICENSE_FILE
+# Some documenting breadcrumbs:
+# flexlm allows for any host id that is displayed with the "lmhostid" tool. For
+# servers this could be the "real" hostid as in /etc/hostid. But with a server
+# based license a daemon needs to be running and also the hostname needs to be
+# fixed. So alternatively use the NIC based host id that is just the MAC addess.
+
+# Entrypoint is the vsim executable.
+ENTRYPOINT ["vsim"]
+# With args "-c -do <script.tcl>" an arbirtrary TCL script can be run.
+# Without the "-c" flag vsim starts in GUI mode.
+# As default do nothing and just print the version.
+CMD ["-version"]

--- a/questasim/README.md
+++ b/questasim/README.md
@@ -1,0 +1,81 @@
+# questasim
+> This image is part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
+> For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
+
+This container contains a continerized version of `Questa  Intel Starter FPGA Edition-64 vsim 2021.2 Simulator 2021.04 Apr 14 2021`.
+
+Questa is a part of [Intel Quartus Prime Lite](https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html). To reduce the size of the image the tools of Quartus have been split up into tow images:
+ - [`quartus`](../quartus/README.md), tools to synthesize HDL for Intel FPGAs
+ - `questasim`, tools to simulate HDL (this one here)
+
+But even with this split, the image is still very big (~4.6 GB). The large _installation step_ image layer is split up into multiple smaller layers to help speed up image pull / download and make it more robust.
+
+## Usage
+The image has `vsim` set as `ENTRYPOINT`. Simply running a container without arguments will invoke `vsim` with the default `CMD` argument `-version` and print the Questa version:
+```shell
+$ docker run ghcr.io/nikleberg/questasim
+> Questa  Intel Starter FPGA Edition-64 vsim 2021.2 Simulator 2021.04 Apr 14 2021
+```
+
+For an actual usage you want to override the `CMD` by giving additional arguments to the `docker run` command. For example to run a simulation tcl script you could run:
+```bash
+$ docker run ghcr.io/nikleberg/questasim -c -do <script>.tcl
+> # Questa Intel Starter FPGA Edition-64 vcom 2021.2 Compiler 2021.04 Apr 14 2021
+  # Start time: 22:15:25 on Oct 12,2023
+  # vcom top.vhdl 
+  # -- Loading package STANDARD
+  # -- Loading package TEXTIO
+  # -- Loading package std_logic_1164
+  ...
+```
+
+### Additional `docker run` Arguments
+For improved functionality and ease-of-use you may want to add some of these arguments to the `docker run` command stated above:
+ - `--hostname vsim`: Make the shells in the container display a human readable machine name.
+ - `--interactive --tty`: This makes the started container interactive and not run in the background.
+ - `--rm`: Removes the container after the command is finished, your disk will thank you.
+ - `--workdir $(pwd)`: Sets the working directory inside the container to the current shell path.
+ - `--volumes-from $(cat /proc/self/cgroup | head -n 1 | cut -d '/' -f3)`: If the container is started in the DooD environment provided by [`dev-base`](../dev-base/README.md) in Devcontainers, then this forwards the required volumes from the base container to the _questasim_ tool container. This is required to access any path in `/workspaces`. 
+ - `--env=DISPLAY=:0 --volume=/tmp/.X11-unix/:/tmp/.X11-unix/`: Forwards your X11 configuration (this works in WSLg!). With this, starting `vsim` without the `-c` flag (CLI mode) starts the GUI of `vsim` (or actually _QuestaSim_) on your docker host.
+ - `--mac-address=00:ab:ab:ab:ab:ab`: Sets a specific MAC address for the docker NIC. This is for licencing purposes, please read below [_License File_](#license-file).
+
+### Alias
+To release your fingers from the pain of entering these commands and arguments all the time, use an alias function.
+
+Put the below functions in a script and `source <script>` it in whatever shell you need the `vsim` command. After this, having `vsim` installed locally is almost identical as having it isolated in this self-contained docker image.
+
+```bash
+function get_common_args () {
+    common_vols="--volumes-from $(cat /proc/self/cgroup | head -n 1 | cut -d '/' -f3)"
+    common_disp="--env=DISPLAY=:0 --volume=/tmp/.X11-unix/:/tmp/.X11-unix/"
+    common_misc="--workdir $(pwd) --interactive --tty --rm"
+    common_args="$common_vols $common_disp $common_misc"
+    echo $common_args
+}
+export -f get_common_args
+
+function vsim () {
+    vsim_args="--hostname vsim --mac-address=00:ab:ab:ab:ab:ab $(get_common_args)"
+    docker run $common_args $vsim_args ghcr.io/nikleberg/questasim:staging $*
+}
+export -f vsim
+function vsim_bash () {
+    vsim_args="--hostname vsim --mac-address=00:ab:ab:ab:ab:ab --entrypoint bash $(get_common_args)"
+    docker run $common_args $vsim_args ghcr.io/nikleberg/questasim:staging $*
+}
+export -f vsim_bash
+```
+
+Note the additional `vsim_bash` alias. It overwrites the entrypoint in the image and lets you more easily debug problems by dropping you into a bash shell inside the container.
+
+### License File
+Since v21.1 of Quartus, ModelSim was replaced by QuestaSim. It requires a valid license that can be obtained from [intel](https://licensing.intel.com/). For ease of use a valid license is already included. But it is bound to a specific NIC id i.e. MAC address `00:ab:ab:ab:ab:ab`.
+
+If you want to use this license you have to set the MAC address for the docker contrainer with the `--mac-address=00:ab:ab:ab:ab:ab` argument when starting the container with `docker run`.
+
+Alternatively you may [aquire your own license file](https://licensing.intel.com/). To use it you have to:
+ - mount the license file into the container with `--volume /path/on/host/license:/path/on/container/license`
+ - set the environment variable `LM_LICENSE_FILE` such that `vsim` finds it with: `--env=LM_LICENSE_FILE=/path/on/container/license`
+
+## License
+[MIT](../LICENSE) © [NikLeberg](https://github.com/NikLeberg).

--- a/questasim/license.dat
+++ b/questasim/license.dat
@@ -1,5 +1,5 @@
 ﻿# Intel Corporation Software and/or Intellectual Property License File
-# Issued 10 October 2022
+# Issued 09 October 2023
 # Upgrade to these products will no longer be available after the Maintenance Expiration  
 # date unless licenses are renewed.  
 # Fixed Node License
@@ -8,20 +8,20 @@
 # Companion ID-N/A
 # Companion ID 2-N/A
 # Product License Summary:
-# Questasim*-Intel® FPGA Starter Edition, 1 Seat(s)
+# 2 Questa*-Intel® FPGA Starter Edition (License: SW-QUESTA), 1 Seat(s)
 # - Maintenance Expiration of 2023.10
-# - License Expires 10-Oct-2023
+# - License Expires 08-Oct-2024
 ################################################################################ 
 # FEATURE START 
-# This is license file for Questasim*-Intel® FPGA Starter Edition 
+# This is license file for Questasim*-Intel FPGA Starter Edition 
 # Number of seat licenses is 1 
-# License Expires 10-Oct-2023 
-INCREMENT intelqsimstarter mgcld 2023.10 10-oct-2023 uncounted \
-  \
-    2F35127AB87AFC9A80AA VENDOR_STRING=993BF9DB HOSTID=00ababababab \
-    ISSUER=Intel SN=282509278 SIGN2="0196 3079 C2BB 2B9A 8CC1 8244 F216 \
-    E07B 9C82 5C3B 9D74 D1A4 3B5A 636B 4D88 03C3 EB8E 0F17 A24B B532 7408 \
-    96DB 7E04 6E86 F537 1DFD C17D A71A 6861 FC83"
+# License Expires 08-Oct-2024 
+INCREMENT intelqsimstarter mgcld 2024.01 8-oct-2024 uncounted \
+  EF7782293BCC13EFC151 \
+    VENDOR_STRING=62C5A525 HOSTID=00ababababab ISSUER=Intel SN=287837015 \
+    SIGN2="07B0 1D6E A213 0C55 3C7E 4F8A 970D 3626 2C61 FFBE 0063 D44E \
+    DE06 36D7 F7D6 0DF1 94EC C5B5 8D6D 18CD 8BC3 0B5F 945E 5BD2 C82D DAFE \
+    CCFE 2DF0 9839 0A5C"
 # FEATURE END 
 ################################################################################
-# End of Intel Corporation Software and/or Intellectual Property License File. Issued 10/10/2022
+# End of Intel Corporation Software and/or Intellectual Property License File. Issued 10/09/2023

--- a/questasim/license.dat
+++ b/questasim/license.dat
@@ -1,0 +1,27 @@
+﻿# Intel Corporation Software and/or Intellectual Property License File
+# Issued 10 October 2022
+# Upgrade to these products will no longer be available after the Maintenance Expiration  
+# date unless licenses are renewed.  
+# Fixed Node License
+# Primary Machine Name-docker-image3
+# Primary Machine ID-NIC ID 00ababababab
+# Companion ID-N/A
+# Companion ID 2-N/A
+# Product License Summary:
+# Questasim*-Intel® FPGA Starter Edition, 1 Seat(s)
+# - Maintenance Expiration of 2023.10
+# - License Expires 10-Oct-2023
+################################################################################ 
+# FEATURE START 
+# This is license file for Questasim*-Intel® FPGA Starter Edition 
+# Number of seat licenses is 1 
+# License Expires 10-Oct-2023 
+INCREMENT intelqsimstarter mgcld 2023.10 10-oct-2023 uncounted \
+  \
+    2F35127AB87AFC9A80AA VENDOR_STRING=993BF9DB HOSTID=00ababababab \
+    ISSUER=Intel SN=282509278 SIGN2="0196 3079 C2BB 2B9A 8CC1 8244 F216 \
+    E07B 9C82 5C3B 9D74 D1A4 3B5A 636B 4D88 03C3 EB8E 0F17 A24B B532 7408 \
+    96DB 7E04 6E86 F537 1DFD C17D A71A 6861 FC83"
+# FEATURE END 
+################################################################################
+# End of Intel Corporation Software and/or Intellectual Property License File. Issued 10/10/2022

--- a/questasim/pre_build.dockerfile
+++ b/questasim/pre_build.dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    LC_CTYPE=C.UTF-8
+
+# Install wget so we can download questa installer.
+RUN <<EOF
+    set -e
+    apt-get -q -y update
+    apt-get -q -y install --no-install-recommends \
+        wget ca-certificates
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Install QuestaSim for Intel FPGAs from:
+# https://www.intel.de/content/www/de/de/products/details/fpga/development-tools/quartus-prime/resource.html
+ARG QUESTA_URL=https://downloads.intel.com/akdlm/software/acdsinst/22.1std.1/917/ib_installers/QuestaSetup-22.1std.1.917-linux.run
+ARG QUESTA_SHA=a10a65aecdf2b2d2bfbfaf1fa159d938b3cab4bf
+ARG QUESTA_VERSION=22.1.1
+ENV QUESTA_ROOTDIR="/opt/QuestaSim/$QUESTA_VERSION"
+RUN <<EOF
+    set -e
+    mkdir questa-tmp
+    cd questa-tmp
+    wget --progress=dot:giga $QUESTA_URL -O QuestaSetup.run
+    echo "$QUESTA_SHA *QuestaSetup.run" | sha1sum --check --strict -
+    chmod +x QuestaSetup.run
+    ./QuestaSetup.run \
+        --mode unattended --accept_eula 1 \
+        --installdir $QUESTA_ROOTDIR
+    cd ..
+    rm -r questa-tmp
+    rm -r $QUESTA_ROOTDIR/uninstall
+    rm -r $QUESTA_ROOTDIR/logs
+EOF

--- a/questasim/pre_build.sh
+++ b/questasim/pre_build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Fail on nonzero return
+set -e
+
+# https://stackoverflow.com/questions/51903877/docker-load-no-space-left-on-device-rhel
+docker system prune -a -f --volumes
+
+# Skip Trivy and Dockle scan steps, image needs too much disk space.
+echo "trivy_skip=skip" >> $GITHUB_OUTPUT
+echo "dockle_skip=skip" >> $GITHUB_OUTPUT
+
+# This docker image gets rather big as it needs to download Questa with a hefty
+# size of more than 2 GB. This would create a single layer in the image with a
+# huge size and that has to be downloaded and can't be parallelized. To break
+# this layer up, a few steps are performed here in this script that is run
+# before the main image is built:
+#  - Download / Extract / Install Questa in a separate docker container.
+#  - Run the image as container so that the `docker export` command works.
+#  - Export the content of that dockerfile to a tar.
+#  - Split the tar as file boundaries into multiple tars.
+#  - The split tars can be imported with multiple layers on the real Dockerfile.
+
+# Build pre_build dockerfile and export its filesystem as tar.
+docker build -t ghcr.io/nikleberg/questasim_pre-build -f pre_build.dockerfile .
+docker create --name questasim_pre-build ghcr.io/nikleberg/questasim_pre-build
+docker export questasim_pre-build -o questasim_pre-build.tar
+docker rm questasim_pre-build
+
+# Split tar into smaller chunks at file boundaries.
+TAR_SPLITTER_URL=https://github.com/AQUAOSOTech/tarsplitter/releases/download/v2.2.0/tarsplitter_linux
+TAR_SPLITTER_SHA=d92d19b36f03eadd25e9ee17d659761a0788b2e5
+wget --progress=dot $TAR_SPLITTER_URL -O tarsplitter
+echo "$TAR_SPLITTER_SHA *tarsplitter" | sha1sum --check --strict -
+chmod +x tarsplitter
+./tarsplitter -i questasim_pre-build.tar -p 5
+rm questasim_pre-build.tar
+rm tarsplitter


### PR DESCRIPTION
New image that packages `QuestaSim` as standalone. In comparison to `quartus-prime` image it does not have `quartus` itself installed.

The diea being to split up the huge quartus image into smaller containerized CLI programs.

ToDo:
- [x] define entrypoint for convenience
- [x] minimize