### PR TITLE
ci: cleanup cache from closed PRs

### DIFF
--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,0 +1,43 @@
+# Cleanup left over caches from merged PRs.
+# Source: https://github.com/actions/cache/blob/main/tips-and-workarounds.md
+
+name: Cache Cleanup
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH=refs/pull/${{ github.event.pull_request.number }}/merge
+
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              echo "Deleting $cacheKey"
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds an additional action that cleans up the leftover caches from closed (merged or not) PRs.
This de-clutters the _10 GB_ cache limit from caches that can't be used anymore. They can't be used because caches are isolated between branches, and the PR was (probably) merged into main. So the next PR or even main will never use it.

See [here](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy) for source.