### PR TITLE
riscv-gcc: new image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,4 +52,8 @@ updates:
     directory: "/quartus"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/riscv-gcc"
+    schedule:
+      interval: "weekly"
   

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ env:
     dev-base
     questasim
     quartus
+    riscv-gcc
   # Names of images that depend on others in stage 1.
   stage_2:
     quartus-prime-aji

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -35,7 +35,6 @@ jobs:
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              echo "Deleting $cacheKey"
               gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
           done
           echo "Done"

--- a/quartus/README.md
+++ b/quartus/README.md
@@ -71,7 +71,7 @@ function command_not_found_handle () {
     if [[ $1 =~ ^quartus.*$ ]]; then
         quartus_args="--hostname quartus --entrypoint $1 $(get_common_args)"
         shift
-        docker run $common_args $quartus_args ghcr.io/nikleberg/quartus $*
+        docker run $quartus_args ghcr.io/nikleberg/quartus $*
         return
     fi
     return 127 # not a quartus command
@@ -79,7 +79,7 @@ function command_not_found_handle () {
 export -f command_not_found_handle
 function quartus_bash () {
     quartus_args="--hostname quartus --entrypoint bash $(get_common_args)"
-    docker run $common_args $quartus_args ghcr.io/nikleberg/quartus $*
+    docker run $quartus_args ghcr.io/nikleberg/quartus $*
 }
 export -f quartus_bash
 ```

--- a/questasim/README.md
+++ b/questasim/README.md
@@ -56,12 +56,12 @@ export -f get_common_args
 
 function vsim () {
     vsim_args="--hostname vsim --mac-address=00:ab:ab:ab:ab:ab $(get_common_args)"
-    docker run $common_args $vsim_args ghcr.io/nikleberg/questasim $*
+    docker run $vsim_args ghcr.io/nikleberg/questasim $*
 }
 export -f vsim
 function vsim_bash () {
     vsim_args="--hostname vsim --mac-address=00:ab:ab:ab:ab:ab --entrypoint bash $(get_common_args)"
-    docker run $common_args $vsim_args ghcr.io/nikleberg/questasim $*
+    docker run $vsim_args ghcr.io/nikleberg/questasim $*
 }
 export -f vsim_bash
 ```

--- a/riscv-gcc/Dockerfile
+++ b/riscv-gcc/Dockerfile
@@ -1,0 +1,59 @@
+# Build risc-v gcc compiler in separate docker builder.
+# Process as described in: https://github.com/riscv-collab/riscv-gnu-toolchain
+FROM ubuntu:jammy as riscv_gcc_builder
+
+# Install prerequisites.
+RUN <<EOF
+    set -e
+    apt-get -q -y update
+    apt-get -q -y install --no-install-recommends \
+        ca-certificates \
+        git autoconf automake autotools-dev curl python3 libmpc-dev \
+        libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf \
+        libtool patchutils bc zlib1g-dev libexpat-dev ninja-build
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Get the sources.
+ARG RISCV_GNU_CLONE_URL=https://github.com/riscv/riscv-gnu-toolchain
+ARG RISCV_GNU_CLONE_TAG=2023.10.12
+RUN git clone $RISCV_GNU_CLONE_URL -b $RISCV_GNU_CLONE_TAG --depth 1
+
+# Build with newlib cross-compiler
+ARG RISCV_TOOLCHAIN_PATH=/opt/riscv
+ARG RISCV_ARCH=rv32imac
+ARG RISCV_ABI=ilp32
+ENV PATH="$RISCV_TOOLCHAIN_PATH/bin:${PATH}"
+RUN <<EOF
+    set -e
+    cd riscv-gnu-toolchain
+    ./configure --prefix=/opt/riscv \
+        --with-arch=$RISCV_ARCH --with-abi=$RISCV_ABI
+    make
+EOF
+
+
+# Put the compiled binaries into a fresh image.
+FROM ubuntu:jammy
+
+# Install host toolchain.
+RUN <<EOF
+    set -e
+    apt-get -q -y update
+    apt-get -q -y install --no-install-recommends \
+        make gcc libc-dev openocd
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Install precompiled risc-v cross compiler toolchain.
+ARG RISCV_TOOLCHAIN_PATH=/opt/riscv
+COPY --from=riscv_gcc_builder $RISCV_TOOLCHAIN_PATH $RISCV_TOOLCHAIN_PATH
+ENV PATH="$RISCV_TOOLCHAIN_PATH/bin:${PATH}"
+ENV RISCV_PREFIX=riscv32-unknown-elf-
+
+# Entrypoint is the gcc cross compiler.
+ENTRYPOINT ["riscv32-unknown-elf-gcc"]
+# As default do nothing and just print the version.
+CMD ["--version"]

--- a/riscv-gcc/README.md
+++ b/riscv-gcc/README.md
@@ -1,0 +1,78 @@
+# riscv-gcc
+> This image is part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
+> For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
+
+This container contains a continerized version of a RISC-V GCC cross-compiler toolchain in version `riscv32-unknown-elf-gcc () 13.2.0`.
+Additionally `make`, `openocd` and a host version of a `gcc` toolchain are installed as well.
+
+## Usage
+The image has `riscv32-unknown-elf-gcc` set as `ENTRYPOINT`. Simply running a container without arguments will invoke `riscv32-unknown-elf-gcc` with the default `CMD` argument `--version` and print the GCC version:
+```
+$ docker run ghcr.io/nikleberg/riscv-gcc
+> riscv32-unknown-elf-gcc () 13.2.0
+  Copyright (C) 2023 Free Software Foundation, Inc.
+  This is free software; see the source for copying conditions.  There is NO
+  warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+For an actual usage you want to override the `CMD` by giving additional arguments to the `docker run` command. For example to actually cross-compile code you could run:
+```
+$ docker run ghcr.io/nikleberg/riscv-gcc main.c -I include/
+> ...
+```
+
+To use `make` or the host `gcc` toolchain you may use the `--entrypoint <binary>` argument when starting the container with `docker run`.
+
+### Additional `docker run` Arguments
+For improved functionality and ease-of-use you may want to add some of these arguments to the `docker run` command stated above:
+ - `--hostname riscv-gcc`: Make the shells in the container display a human readable machine name.
+ - `--interactive --tty`: This makes the started container interactive and not run in the background.
+ - `--rm`: Removes the container after the command is finished, your disk will thank you.
+ - `--workdir $(pwd)`: Sets the working directory inside the container to the current shell path.
+ - `--volumes-from $(cat /proc/self/cgroup | head -n 1 | cut -d '/' -f3)`: If the container is started in the DooD environment provided by [`dev-base`](../dev-base/README.md) in Devcontainers, then this forwards the required volumes from the base container to the _quartus_ tool container. This is required to access any path in `/workspaces`.
+
+### Alias
+To release your fingers from the pain of entering these commands and arguments all the time, use an alias function.
+
+Put the below functions in a script and `source <script>` it in whatever shell you need the gcc toolchain. After this, having gcc installed locally is almost identical as having it isolated in this self-contained docker image.
+
+```bash
+function get_common_args () {
+    common_vols="--volumes-from $(cat /proc/self/cgroup | head -n 1 | cut -d '/' -f3)"
+    common_misc="--workdir $(pwd) --interactive --tty --rm"
+    common_args="$common_vols $common_misc"
+    echo $common_args
+}
+export -f get_common_args
+
+function make () {
+    riscv_args="--hostname riscv-gcc --entrypoint make $(get_common_args)"
+    docker run $riscv_args ghcr.io/nikleberg/riscv-gcc $*
+}
+export -f make
+function riscv32-unknown-elf-gcc () {
+    riscv_args="--hostname riscv-gcc --entrypoint riscv32-unknown-elf-gcc $(get_common_args)"
+    docker run $riscv_args ghcr.io/nikleberg/riscv-gcc $*
+}
+export -f riscv32-unknown-elf-gcc
+function gcc () {
+    riscv_args="--hostname riscv-gcc --entrypoint gcc $(get_common_args)"
+    docker run $riscv_args ghcr.io/nikleberg/riscv-gcc $*
+}
+export -f gcc
+function openocd () {
+    riscv_args="--hostname riscv-gcc --entrypoint openocd $(get_common_args)"
+    docker run $riscv_args ghcr.io/nikleberg/riscv-gcc $*
+}
+export -f openocd
+function riscv_bash () {
+    riscv_args="--hostname riscv-gcc --entrypoint bash $(get_common_args)"
+    docker run $riscv_args ghcr.io/nikleberg/riscv-gcc $*
+}
+export -f riscv_bash
+```
+
+Note the additional `riscv_bash` alias is for debugging. It overwrites the entrypoint in the image and lets you more easily debug problems by dropping you into a bash shell inside the container.
+
+## License
+[MIT](../LICENSE) © [NikLeberg](https://github.com/NikLeberg).


### PR DESCRIPTION
This extracts the `ricv-gcc` cross-compiler from `neorv32_soc` image into its own image. This is in alignment with the current movement to reduce dependencies between images and using the `dev-base` DooD idea.