### PR TITLE
quartus: fix failing CI build

### DIFF
--- a/quartus/post_build.sh
+++ b/quartus/post_build.sh
@@ -3,8 +3,5 @@
 # Fail on nonzero return
 set -e
 
-# Clean up files from pre_build.sh.
-rm *.tar
-
 # Build / run the test dockerfile.
 docker build -f tests.dockerfile .


### PR DESCRIPTION
The CI does simply put:
- run pre_build.sh
- build staging release
- run post_build.sh
- build latest release

The `latest` build requires the `*.tar` file to be around otherwise their checksum can't be calculated. Fixing by not removing the tar files.