### PR TITLE
questa: fix failing CI build

### DIFF
--- a/questasim/post_build.sh
+++ b/questasim/post_build.sh
@@ -3,9 +3,6 @@
 # Fail on nonzero return
 set -e
 
-# Clean up files from pre_build.sh.
-rm *.tar
-
 # We need to set the container MAC address while building the tests.dockerfile.
 # For this we start a dummy alpine container with the needed MAC address and
 # then build the test container with the network of that dummy container


### PR DESCRIPTION
The CI does simply put:
- run pre_build.sh
- build staging release
- run post_build.sh
- build latest release

The latest build requires the *.tar file to be around otherwise their checksum can't be calculated. Fixing by not removing the tar files.