### PR TITLE
ci: allow dependabot to push to packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
 
   collect:

--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -27,6 +27,7 @@ jobs:
       matrix: ${{fromJson(inputs.builderMatrix)}}
     env:
       baseTag: ${{inputs.registry}}/${{inputs.username}}/${{matrix.name}}
+    name: ${{matrix.name}}:${{matrix.tag}}
     steps:
 
       - name: Maximize Build Space

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To build your image for `amd64` and also `riscv64` add to your `containers.json`
 ```
 
 ### Testing
-Testing you images is an important step in ensuring they do or contain what you actually intend them to do. For this specify `testScript` with a path inside your `<image_name_folder>`. The script is ran after the staging version of your image has been built, so the tag know by docker will be `ghcr.io/nikleberg/<image_name>:<image_tag>-staging`. The script is called with the `<image_tag>` as its first argument.
+Testing your images is an important step in ensuring they do or contain what you actually intend them to do. For this specify `testScript` with a path inside your `<image_name_folder>`. The script is ran after the staging version of your image has been built, so the tag know by docker will be `ghcr.io/nikleberg/<image_name>:<image_tag>-staging`. The script is called with the `<image_tag>` as its first argument.
 
 ```json
 [


### PR DESCRIPTION
Previously CI that was run for PRs opened by dependabot were not able to push to the ghcr.io registry due to the restricted GITHUB_TOKEN.

Adding a "permissions" field should solve this.

See:
- https://github.com/docker/build-push-action/issues/687
- https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
- https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-work
flows/