### PR TITLE
ci: allow dependabot PRs to update security-events

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   packages: write
+  security-events: write
 
 jobs:
 

--- a/.github/workflows/collect.py
+++ b/.github/workflows/collect.py
@@ -170,7 +170,7 @@ def reduceStagesToChangedAndDependencies(stages: list, changedContainers: list) 
 
 # Build the GHA (GitHub Actions) matrix definitions for the containers.
 def buildGHAMatrices(stages: list) -> list:
-    return [{"include": [c.getGHAMatrix() for c in stage]} for stage in stages]
+    return [{"include": [c.getGHAMatrix() for c in s]} for s in stages if s]
 
 # Set step output for GHA, prints to STDIO if not in CI.
 def setGHAOutput(matrices: list) -> None:

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |


### PR DESCRIPTION
Without this permission PRs triggered by dependabot or other users won't be able to run the `github/codeql-action/upload-sarif` action which gives the following error:


>This run of the CodeQL Action does not have permission to access Code Scanning API endpoints. As a result, it will not be opted into any experimental features. This could be because the Action is running on a pull request from a fork. If not, please ensure the Action has the 'security-events: write' permission.
Details: Resource not accessible by integration