### PR TITLE
riscv-gcc: add rv32i march

### DIFF
--- a/riscv-gcc/containers.json
+++ b/riscv-gcc/containers.json
@@ -13,7 +13,7 @@
         "name": "riscv-gcc",
         "tags": "13.2-rv32imac",
         "args": [
-            "RISCV_GNU_CLONE_TAG=2024.04.12",
+            "RISCV_GNU_CLONE_TAG=2024.08.06",
             "RISCV_ARCH=rv32imac",
             "RISCV_ABI=ilp32"
         ],

--- a/riscv-gcc/containers.json
+++ b/riscv-gcc/containers.json
@@ -18,5 +18,15 @@
             "RISCV_ABI=ilp32"
         ],
         "maximizeBuildSpace": true
+    },
+    {
+        "name": "riscv-gcc",
+        "tags": "13.2-rv32i",
+        "args": [
+            "RISCV_GNU_CLONE_TAG=2024.08.06",
+            "RISCV_ARCH=rv32i",
+            "RISCV_ABI=ilp32"
+        ],
+        "maximizeBuildSpace": true
     }
 ]


### PR DESCRIPTION
Add minimal `rv32i` march.