### PR TITLE
nvc: new image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,4 +44,8 @@ updates:
     directory: "/riscv-gcc"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/nvc"
+    schedule:
+      interval: "weekly"
   

--- a/nvc/Dockerfile
+++ b/nvc/Dockerfile
@@ -1,0 +1,85 @@
+# Based off https://github.com/hdl/containers/blob/main/debian-bullseye/nvc/Dockerfile
+FROM ubuntu:jammy AS builder
+
+ARG NVC_VERSION
+ARG NVC_SIG_KEY
+ARG LLVM_VERSION
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    LC_CTYPE=C.UTF-8
+
+# Install neccessary build tools and dependencies.
+RUN <<EOF
+    set -e
+    apt-get -q -y update
+    apt-get -q -y install \
+        wget \
+        gpg \
+        automake \
+        autoconf \
+        check \
+        flex \
+        bison \
+        libdw-dev \
+        libffi-dev \
+        llvm-$LLVM_VERSION-dev \
+        pkg-config \
+        zlib1g-dev \
+        libzstd-dev \
+        tcl-dev \
+        libreadline-dev
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Build from signed tarball.
+ARG NV_TARBALL=nvc-$NVC_VERSION.tar.gz
+ARG NVC_TARBALL_URL=https://github.com/nickg/nvc/releases/download/r$NVC_VERSION/$NV_TARBALL
+ARG NVC_SIG_URL=https://github.com/nickg/nvc/releases/download/r$NVC_VERSION/$NV_TARBALL.sig
+RUN <<EOF
+    set -e
+    wget --progress=dot $NVC_TARBALL_URL
+    wget --progress=dot $NVC_SIG_URL
+    gpg --keyserver keyserver.ubuntu.com --recv-keys $NVC_SIG_KEY
+    gpg --verify $NV_TARBALL.sig $NV_TARBALL
+    tar xvzf $NV_TARBALL
+    mkdir ./nvc-$NVC_VERSION/build
+    cd ./nvc-$NVC_VERSION/build
+    ../configure \
+        --with-llvm=/usr/lib/llvm-$LLVM_VERSION/bin/llvm-config \
+        --enable-tcl
+    make -j$(nproc)
+    make DESTDIR=/opt/nvc install
+EOF
+
+# Import built NVC into clean container.
+FROM ubuntu:jammy AS base
+
+ARG LLVM_VERSION
+
+COPY --from=builder /opt/nvc /
+
+# Install neccessary runtime dependencies.
+RUN <<EOF
+    set -e
+    apt-get -q -y update
+    apt-get -q -y install --no-install-recommends \
+        binutils \
+        libdw1 \
+        libllvm$LLVM_VERSION \
+        make \
+        libzstd1 \
+        libtcl8.6 \
+        libreadline8
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Entrypoint is the NVC executable.
+ENTRYPOINT ["nvc"]
+# With e.g. args "-a <file.vhd>" a VHDL design can be analyzed.
+# See the manual for more options https://www.nickg.me.uk/nvc/manual.html.
+# As default do nothing and just print the version.
+CMD ["--version"]

--- a/nvc/README.md
+++ b/nvc/README.md
@@ -1,0 +1,69 @@
+# nvc
+> This image is part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
+> For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
+
+This container contains a continerized version of `nvc` - _VHDL compiler and simulator_ from [nickg/nvc](www.nickg.me.uk/nvc/).
+
+## Tags
+| Tag(s) | NVC Version | LLVM Version |Note |
+|---|---|---|
+| `1.13.3` `latest` | 1.13.3 | 14 | - |
+
+Feel free to open an issue to request other versions.
+
+## Usage
+The image has `nvc` set as `ENTRYPOINT`. Simply running a container without arguments will invoke `nvc` with the default `CMD` argument `--version` and print the nvc version:
+```shell
+$ docker run ghcr.io/nikleberg/nvc
+> nvc 1.13.3 (Using LLVM 14.0.0)
+> Copyright (C) 2011-2024  Nick Gasson
+> This program comes with ABSOLUTELY NO WARRANTY. This is free software, and
+> you are welcome to redistribute it under certain conditions. See the GNU
+> General Public Licence for details.
+```
+
+For an actual usage you want to override the `CMD` by giving additional arguments to the `docker run` command. For example to run a tcl script you could run:
+```bash
+$ docker run ghcr.io/nikleberg/nvc --do <script>.tcl
+```
+
+See the [official manual](https://www.nickg.me.uk/nvc/manual.html) for more options.
+
+### Additional `docker run` Arguments
+For improved functionality and ease-of-use you may want to add some of these arguments to the `docker run` command stated above:
+ - `--hostname nvc`: Make the shells in the container display a human readable machine name.
+ - `--interactive --tty`: This makes the started container interactive and not run in the background.
+ - `--rm`: Removes the container after the command is finished, your disk will thank you.
+ - `--workdir $(pwd)`: Sets the working directory inside the container to the current shell path.
+ - `--volumes-from $(cat /proc/self/cgroup | head -n 1 | cut -d '/' -f3)`: If the container is started in the DooD environment provided by [`dev-base`](../dev-base/README.md) in Devcontainers, then this forwards the required volumes from the base container to the _nvc_ tool container. This is required to access any path in `/workspaces`. 
+
+### Alias
+To release your fingers from the pain of entering these commands and arguments all the time, use an alias function.
+
+Put the below functions in a script and `source <script>` it in whatever shell you need the `nvc` command. After this, having `nvc` installed locally is almost identical as having it isolated in this self-contained docker image.
+
+```bash
+function get_common_args () {
+    common_vols="--volumes-from $(cat /proc/self/cgroup | head -n 1 | cut -d '/' -f3)"
+    common_misc="--workdir $(pwd) --interactive --tty --rm"
+    common_args="$common_vols $common_misc"
+    echo $common_args
+}
+export -f get_common_args
+
+function nvc () {
+    nvc_args="--hostname nvc $(get_common_args)"
+    docker run $nvc_args ghcr.io/nikleberg/nvc $*
+}
+export -f nvc
+function nvc_bash () {
+    nvc_args="--hostname nvc --entrypoint bash $(get_common_args)"
+    docker run $nvc_args ghcr.io/nikleberg/nvc $*
+}
+export -f nvc_bash
+```
+
+Note the additional `nvc_bash` alias. It overwrites the entrypoint in the image and lets you more easily debug problems by dropping you into a bash shell inside the container.
+
+## License
+[MIT](../LICENSE) © [NikLeberg](https://github.com/NikLeberg).

--- a/nvc/containers.json
+++ b/nvc/containers.json
@@ -9,6 +9,7 @@
             "NVC_VERSION=1.13.3",
             "NVC_SIG_KEY=BCDB295F74319F1A",
             "LLVM_VERSION=14"
-        ]
+        ],
+        "testScript": "tests.sh"
     }
 ]

--- a/nvc/containers.json
+++ b/nvc/containers.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "nvc",
+        "tags": [
+            "1.13.3",
+            "latest"
+        ],
+        "args": [
+            "NVC_VERSION=1.13.3",
+            "NVC_SIG_KEY=BCDB295F74319F1A",
+            "LLVM_VERSION=14"
+        ]
+    }
+]

--- a/nvc/tests.dockerfile
+++ b/nvc/tests.dockerfile
@@ -1,0 +1,19 @@
+# Pull in the just built image and simulate an example design.
+ARG IMAGE_TAG
+FROM ghcr.io/nikleberg/nvc:${IMAGE_TAG}-staging
+
+COPY <<EOF test.vhd
+entity ent is
+end entity;
+
+architecture arch of ent is
+begin
+    assert false report "Test OK" severity note;
+end architecture;
+EOF
+
+RUN <<EOF
+    set -e
+    nvc -a test.vhd
+    nvc -e ent -r
+EOF

--- a/nvc/tests.sh
+++ b/nvc/tests.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Fail on nonzero return
+set -e
+
+# Check the NVC executable is available.
+testExe () {
+    cmd="docker run ghcr.io/nikleberg/nvc:$1-staging"
+    echo "Running command '$cmd'."
+    $cmd | tee out.log
+
+    if ! test $(grep -c "nvc $1" out.log) -eq 1; then
+        echo "Incorrect version of NVC did start."
+        exit 1
+    fi
+}
+
+# Simulate a test design.
+testDesign () {
+    cmd="docker build --build-arg IMAGE_TAG=$1 --progress plain -f tests.dockerfile ."
+    echo "Running command '$cmd'."
+    $cmd 2>&1 | tee out.log
+
+    if ! test $(grep -c "Test OK" out.log) -eq 1; then
+        echo "VHDL test design could not be analyzed/elaborated/run."
+        exit 1
+    fi
+}
+
+# Choose test depending on the given tag of the container/image.
+case $1 in
+    1.13.3)
+        testExe $1
+        testDesign $1;;
+    *)
+        echo "Unknown image tag to test against. Aborting."
+        exit 1;;
+esac


### PR DESCRIPTION
Add the excellent [nickg/nvc](https://github.com/nickg/nvc) VHDL simulator as prebuilt package.

Partly based off: [hdl/containers/blob/main/debian-bullseye/nvc/Dockerfile](https://github.com/hdl/containers/blob/main/debian-bullseye/nvc/Dockerfile) which sadly seems to not be maintained anymore. 