### PR TITLE
ci: fix security scanning configuration name

### DIFF
--- a/.github/workflows/container_builder.yml
+++ b/.github/workflows/container_builder.yml
@@ -113,6 +113,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: .
+          matrix: '{"name":"${{matrix.mainTag}}"}'
 
       - name: Generate Docker Release Metadata
         uses: docker/metadata-action@v5


### PR DESCRIPTION
The name of the security-configuration is based on the ci-matrix. This generates super long names for the configurations. This tries to fix that.