### PR TITLE
aji_openocd: document working state

### DIFF
--- a/.github/workflows/collect.py
+++ b/.github/workflows/collect.py
@@ -155,6 +155,10 @@ def getChangedFiles():
     else:
         # On a branch, compare with latest main
         changedFiles = run(["git", "diff", "--name-only", latestMainCommit, currentCommit]).split("\n")
+
+    # Ignore changes to README.md.
+    changedFiles = [f for f in changedFiles if not "README.md" in f]
+
     print(f"  Changed files: {changedFiles}")
 
     # Check if git commit log contains "[ci::ignore_workflow_change]" directive.

--- a/aji_openocd/Dockerfile
+++ b/aji_openocd/Dockerfile
@@ -2,33 +2,38 @@ FROM ubuntu:18.04 AS openocd_builder
 
 # Install neccessary tools and dependencies, libaji_client and aji_openocd use
 # old compiler flags that are incompatible with gcc > 8.
-RUN apt-get -q -y update \
-    && apt-get -q -y install \
+RUN <<EOF
+    set -e
+    apt-get -q -y update
+    apt-get -q -y install \
         autoconf automake m4 libtool pkg-config texinfo \
         make gcc-8 g++-8 \
-        git \
-        libusb-1.0-0-dev libftdi-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives \
+        git
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+    update-alternatives \
         --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 \
-        --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
-    && update-alternatives --config gcc
+        --slave /usr/bin/g++ g++ /usr/bin/g++-8
+    update-alternatives --config gcc
+EOF
 
 # Clone, configure and build libaji_client
 # The library has -Werror enabled and has warnings that we cant fix, the below
 # sed commands fix the hard errors to just warnings.
 ARG LIBAJI_CLONE_URL=https://github.com/intel/libaji_client.git
 ARG LIBAJI_CLONE_TAG=R22.4
-RUN git clone $LIBAJI_CLONE_URL -b $LIBAJI_CLONE_TAG --depth 1 \
-    && cd libaji_client \
-    && ./bootstrap \
-    && ./configure \
-    && sed -i 's/#           error/\/\/#           error/g' ./src/h/aji_macros_sys.h \
-    && sed -i 's/-Werror / /g' ./Makefile \
-    && sed -i 's/-Werror / /g' ./src/jtag/Makefile \
-    && make \
-    && cd ..
+RUN <<EOF
+    set -e
+    git clone $LIBAJI_CLONE_URL -b $LIBAJI_CLONE_TAG --depth 1
+    cd libaji_client
+    ./bootstrap
+    ./configure
+    sed -i 's/#           error/\/\/#           error/g' src/h/aji_macros_sys.h
+    sed -i 's/-Werror / /g' Makefile
+    sed -i 's/-Werror / /g' src/jtag/Makefile
+    make
+    cd ..
+EOF
 
 # Clone, configure and build aji_openocd
 #
@@ -36,29 +41,28 @@ RUN git clone $LIBAJI_CLONE_URL -b $LIBAJI_CLONE_TAG --depth 1 \
 # g++ instead of gcc. The following removes unsupported gcc compiler flags from
 # the makefiles, then builds the project once. The build will fail during
 # linking. A second make invocation then actually links with g++. If the project
-# is not (partly) compiled already make seems to call configure to fix the
+# is not (partly) compiled already, make seems to call configure to fix the
 # makefile. So changing the linker and builing in one go is not possible.
 ARG AJI_OPENOCD_CLONE_URL=https://github.com/intel/aji_openocd.git
 ARG AJI_OPENOCD_CLONE_TAG=R22.4
-RUN git clone $AJI_OPENOCD_CLONE_URL -b $AJI_OPENOCD_CLONE_TAG --depth 1 \
-    && cd aji_openocd \
-    && ./bootstrap \
-    && ./configure --enable-aji_client --enable-usb-blaster \
-    && cp ./../libaji_client/src/jtag/.libs/libaji_client.a ./src/ \
-    && sed -i 's/-fstack-clash-protection / /g' ./src/jtag/drivers/aji_client/Makefile.am \
-    && sed -i 's/-fstack-clash-protection / /g' ./src/jtag/drivers/aji_client/aji/Makefile.am \
-    && make || true \
-    && sed -i 's/CCLD = \$(CC)/CCLD = g++/g' ./Makefile \
-    && make
+RUN <<EOF
+    set -e
+    git clone $AJI_OPENOCD_CLONE_URL -b $AJI_OPENOCD_CLONE_TAG --depth 1
+    cd aji_openocd
+    ./bootstrap
+    ./configure --enable-aji_client
+    cp ../libaji_client/src/jtag/.libs/libaji_client.a src/
+    sed -i 's/-fstack-clash-protection / /g' src/jtag/drivers/aji_client/Makefile.am
+    sed -i 's/-fstack-clash-protection / /g' src/jtag/drivers/aji_client/aji/Makefile.am
+    make || true
+    sed -i 's/CCLD = \$(CC)/CCLD = g++/g' Makefile
+    make
+EOF
 
-# Import built openocd into clean container.
+# Import built OpenOCD into clean container.
 FROM ubuntu:26.04
 COPY --from=openocd_builder /aji_openocd/src/openocd /opt/aji_openocd/
 COPY --from=openocd_builder /aji_openocd/tcl /opt/aji_openocd/tcl
 
-# Install additional required packages for USB FTDI JTAG support
-RUN apt-get -q -y update \
-    && apt-get -q -y install \
-        libusb-1.0-0 libftdi-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Add OpenOCD to path.
+ENV PATH="/opt/aji_openocd/:${PATH}"

--- a/aji_openocd/README.md
+++ b/aji_openocd/README.md
@@ -3,58 +3,103 @@
 > For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
 Companion to the [`quartus`](../quartus/README.md) image with AJI virtual JTAG infrastructure and OpenOCD. It allows to use this virtual JTAG system with OpenOCD for example to debug IP Cores in the FPGA.
 
-This image contains a continerized version of the following [OpenOCD](https://github.com/intel/aji_openocd) fork from Intel that enables aji.
+This image contains a containerized version of the following [OpenOCD](https://github.com/intel/aji_openocd) fork from Intel that enables AJI.
 
-## WIP
-This is a work-in-progress. To do:
- - document how to integrate with the dev-base style container images
- - how to network forward the openocd sockets
- - actually get it to work with NEORV32
+Note that OpenOCD was only compiled with AJI support. All other adapters (USB, FTDI, etc.) are not compiled in.
 
 ## What is AJI?
-AJI stands for Altera Virtual JTAG Interface. It enables the extenstion of the physical JTAG chain with ore or multiple virtual JTAG chains inside the FPGA fabric. This is extensively used for Altera's own products like _Signal Tap Logic Analyzer_ or _NIOS II Debugger_. But by instanciating the [`sld_virtual_jtag`](https://cdrdv2-public.intel.com/666577/ug_virtualjtag-683705-666577.pdf) entity one can extend this with custom JTAG TAPs. The required System Level Debug (SLD) infrastructure is then automatically instantiated when synthesizing with quartus. See the excellent [blog](https://tomverbeure.github.io/2021/05/02/Intel-JTAG-UART.html#the-intels-virtual-jtag-system) of tomverbeure for more in depth explanation.
+AJI stands for Altera Virtual JTAG Interface (sometimes also abbreviated to VJI). It enables the extension of the physical JTAG chain with one or multiple virtual JTAG chains inside the FPGA fabric. This is extensively used for Altera's own products like _Signal Tap Logic Analyzer_ or _NIOS II Debugger_. But by instantiating the [`sld_virtual_jtag`](https://docs.altera.com/r/docs/683705/current) entity one can extend this with custom JTAG TAPs. The required System Level Debug (SLD) infrastructure is then automatically instantiated when synthesizing with quartus. See the excellent [blog post](https://tomverbeure.github.io/2021/05/02/Intel-JTAG-UART.html#the-intels-virtual-jtag-system) of tomverbeure for a more in depth explanation.
 
 ## Usage
-To access the _USB Blaster_ hardware we need to forward the USB tree to the docker container. We do this by mounting the full `/dev` tree and giving it privileged access. One could also only map the specific USB device but this would not survive a un-plug / re-plug.
-Forwarding can be done with the following run flags:
+To start, the `jtagd` server from the [quartus](../quartus/README.md) image must be accessible. The simplest solution is to augment the quartus image's run arguments with `--net=host` to make it use the host network.
+
+Then start a container from this image with the same `--net=host` flag to be able to connect to the JTAG server:
 ```shell
-docker run --privileged -v /dev/bus/usb:/dev/bus/usb ghcr.io/nikleberg/aji_openocd
+$ docker run --net=host ghcr.io/nikleberg/aji_openocd
 ```
 
-Inside the container you need to start the jtag server of quartus before you can connect with OpenOCD. The quartus programmer uses the same server, so either start the programmer after which the server will live on for about ~2 mins, or start the server manually with the below command. The server should stay around and allow every access from the local host (e.g. OpenOCD).
-```shell
-jtagd
+After that you can start OpenOCD inside the container and connect to the virtual JTAG inside the FPGA. OpenOCD expects a script with name `openocd.cfg` in the current directory. Alternatively you can specify the exact script file to run with the `-f` flag.
+```bash
+$ openocd -f <script.cfg>
+```
+See the example script [`neorv32_aji.cfg`](neorv32_aji.cfg) that sets this up for the excellent [NEORV32](https://github.com/stnolting/neorv32) soft core running on a Cyclone IV E. Or have a look at the Intel examples in `/opt/aji_openocd/tcl/boards` where you find `altera_arria10__aji_client.cfg` and `altera_arria10_niosv__aji_client.cfg`.
+
+Output of OpenOCD should look something like this:
+```
+Open On-Chip Debugger 0.11.0-R22.4-gc5bf4f3-dirty (2026-06-21-10:20)
+Licensed under GNU GPL v2
+For bug reports, read
+        http://openocd.org/doc/doxygen/bugs.html
+Info : only one transport option; autoselect 'jtag'
+Info : Application name is OpenOCD.20260628174710
+Info : No cable specified, so will be searching for cables
+
+Info : At present, The first hardware cable will be used [1 cable(s) detected]
+Info : Cable 1: device_name=(null), hw_name=USB-Blaster, server=(null), port=1-4, chain_id=0x55677f515100, persistent_id=1, chain_type=1, features=14336, server_version_info=Version 25.1std.0 Build 1129 10/21/2025 SC Standard Edition
+Info : TAP position 0 (20F20DD) has 5 SLD nodes
+Info :     node  0 idcode=0C006E00 position_n=0
+Info :     node  1 idcode=00406E00 position_n=0
+Info :     node  2 idcode=0C006E01 position_n=0
+Info :     node  3 idcode=0C006E02 position_n=0
+Info :     node  4 idcode=30006E00 position_n=0
+Info : Discovered 1 TAP devices
+Info : Detected device (tap_position=0) device_id=020f20dd, instruction_length=10, features=4, device_name=10CL016(Y|Z)/EP3C16/EP4CE15
+Info : Found an Intel device at tap_position 0.Currently assuming it is SLD Hub
+Info : This adapter doesn't support configurable speed
+Info : JTAG tap: cycloneive.tap tap/device found: 0x020f20dd (mfg: 0x06e (Altera), part: 0x20f2, ver: 0x0)
+Info : JTAG tap: cycloneive.tap Parent Tap found: 0x020f20dd (mfg: 0x06e (Altera), part: 0x20f2, ver: 0x0)
+Info : Virtual Tap/SLD node 0x00406E00 found at tap position 0 vtap position 1
+Info : datacount=1 progbufsize=2
+Info : Disabling abstract command reads from CSRs.
+Info : Examined RISC-V core; found 2 harts
+Info :  hart 0: XLEN=32, misa=0x40800100
+Info :  hart 1: currently disabled
+Info : starting gdb server for cycloneive.neorv32_cpu on 3333
+Info : Listening on port 3333 for gdb connections
+Info : Listening on port 6666 for tcl connections
+Info : Listening on port 4444 for telnet connections
 ```
 
-To check if the USB Blaster is detected correctly run the following command:
+If all went well then OpenOCD is now exposing a GDB server on port `3333` (default) and you may debug the soft core if you have specified it. Alternatively if you only have simple IR / DR registers in your virtual JTAG TAP you can access them with the lowlevel JTAG commands `irscan` and `drscan` in OpenOCD. See [here](https://openocd.org/doc-release/html/JTAG-Commands.html) for documentation.
+
+### Additional Debugging
+The whole AJI system has a _LOT_ of moving parts and many things can go wrong. The following are some known failure modes and how to mitigate or debug them.
+
+If OpenOCD reports:
+```
+Error: Failed to query server for hardware cable information.  Return Status is 82 (AJI_SERVER_ERROR)
+Error: Cannot select JTAG Cable. Return status is 82 (AJI_SERVER_ERROR)
+```
+Then this likely means that the `jtagd` server isn't running. Start it inside the quartus container by running `jtagd` in a shell or by simply programming the FPGA once with the Quartus Programmer which will start the server for you.
+This error also manifests if the two containers can't connect to each other i.e. don't share the same network. Ensure you really started both of them in the same container network or with the `--net=host` flag.
+
+Or if you encounter:
+```
+Error: JTAG server reports that it has no hardware cable
+Error: Cannot select JTAG Cable. Return status is 86 (AJI_BAD_HARDWARE)
+```
+Then this likely means that your FPGA board isn't plugged in. I'd plug it in if I were you.
+If it still can't detect the download cable, check the jtag enumeration by running (in the quartus container):
 ```shell
-jtagconfig --enum
+$ jtagconfig --enum
 ```
-It should output the detected cable name and the attached FPGA. Something like so:
+It should output the detected cable name and the attached FPGA. Something like:
 ```
-root@aji_openocd:~# jtagconfig --enum
 1) USB-Blaster [1-1]
   020F20DD   10CL016(Y|Z)/EP3C16/EP4CE15
 ```
 
-After that you can start OpenOCD and connect to the virtual JTAG inside the FPGA. OpenOCD expects a script with name `openocd.cfg` in the current directory. Alternatively you can specify the exact script file to run with the `-f` flag.
+To debug the enumeration of virtual SLD JTAG TAPs there is the `system-console` GUI program that lists the detected endpoints. Run it inside the quartus container with:
 ```bash
-/opt/aji_openocd/openocd -f <script.cfg>
+$ $QUARTUS_ROOTDIR/quartus/sopc_builder/bin/system-console
 ```
-See the example script [`neorv32.cfg`](neorv32.cfg) that sets this up for the excellent [NEORV32](https://github.com/stnolting/neorv32) soft core running on a Cyclone IV E. Or have a look at the Intel examples in `/opt/aji_openocd/tcl/boards` where you find `altera_arria10__aji_client.cfg` and `altera_arria10_niosv__aji_client.cfg`.
+In the left side of the window in the _System Explorer_ expand _devices_ > \<FPGA type\> > _(link)_ > _JTAG_. There you find the SLD nodes that are described within the FPGA.
 
-OpenOCD now exposes a GDB server on port `3333` (default) and you may debug the soft core if you have specified it. Alternatively if you only have simple IR / DR registers in your virtual JTAG TAP you can access them with the lowlevel JTAG commands `irscan` and `drscan` in OpenOCD. See [here](https://openocd.org/doc-release/html/JTAG-Commands.html) for documentation.
-
-## Additional Information
-Note that OpenOCD was only compiled with AJI support. All other adapters (USB, FTDI, etc.) are not compiled in.
-
-To debug the enumeration of virtual SLD JTAG TAPs there is the `system-console` that lists the detected endpoints. To use it you need to install an additional package beforehand:
-```bash
-apt update
-apt install libxi-dev
-$QUARTUS_ROOTDIR/quartus/sopc_builder/bin/system-console
-```
-In the left side of the window in the _System Explorer_ expand _devices_ > \<FPGA type\> > _(link)_ > _JTAG_. There you find the SLD nodes that are described within in the FPGA.
+### Additional `docker run` Arguments
+For improved functionality and ease-of-use you may want to add some of these arguments to the `docker run` command stated above:
+ - Anything mentioned in [`dev-base`](../dev-base/README.md)
+ - `--volume=/dev:/dev --privileged`: Allows USB/JTAG access to FPGAs for programming.
+ - `--net=host`: Use host network. This allows OpenOCD to access the JTAG server from Quartus. Additionally this then allows other containers to connect to the GDB server. Alternatively you may configure a shared container network.
 
 ## License
 [MIT](./../LICENSE) © [NikLeberg](https://github.com/NikLeberg).

--- a/aji_openocd/neorv32_aji.cfg
+++ b/aji_openocd/neorv32_aji.cfg
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+
+# The following requires the Quartus jtagd server to be running.
+adapter driver aji_client
+
+# Altera Cyclone IV E FPGA
+if { [info exists CHIPNAME] } {
+    set _CHIPNAME $CHIPNAME
+} else {
+    set _CHIPNAME cycloneive
+}
+
+# Subsidiary TAP: fpga (tap)
+# EP4CE15F23C8 has id 0x020f20dd
+jtag newtap $_CHIPNAME tap -irlen 10 -expected-id 0x020f20dd
+
+# Virtual JTAG TAP via SLD.
+# Quartus reports some information about the whole virtual JTAG and SLD chain
+# after synthesis. It is reported in Analysis & Synthesis > Debug Setting
+# Summary > Virtual JTAG Settings. Of importance is the node instance id
+# reported as NODE_INST_ID.
+# ID of SLD nodes is build with the following information:
+# 0x00 - Node Version: Identifies the version of the SLD node
+# 0x40 - NODE_ID: Identifies the type of NODE IP (0x40 for the vJTAG IP core)
+# 0x6E - NODE_MFG_ID_SLD: Node Manufacturer ID (0x6E for vJTAG IP core)
+# 0x?? - NODE_INST_ID: Used to distinguish multiple instances of the same IP and
+#        corresponds to the instance index assigned in the editor. Quartus
+#        reports this id in Analysis & Synthesis > Debug Setting Summary >
+#        Virtual JTAG Settings. An may be set with the VHDL generic
+#        "sld_instance_index" of the "sld_virtual_jtag" instance.
+# Together this gives an id of 0x00406e00 for SLD node with instance id 0.
+vjtag create $_CHIPNAME.tap.sld -chain-position $_CHIPNAME.tap -expected-id 0x00406e00
+
+# NEORV32 target https://github.com/stnolting/neorv32
+set _TARGETNAME $_CHIPNAME.neorv32_cpu
+target create $_TARGETNAME riscv -chain-position $_CHIPNAME.tap.sld
+
+# Shutdown OpenOCD when GDB connection terminates
+$_TARGETNAME configure -event gdb-detach {shutdown}
+
+init
+halt

--- a/nvc/README.md
+++ b/nvc/README.md
@@ -2,7 +2,7 @@
 > This image is part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
 > For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
 
-This container contains a continerized version of `nvc` - _VHDL compiler and simulator_ from [nickg/nvc](www.nickg.me.uk/nvc/).
+This container contains a containerized version of `nvc` - _VHDL compiler and simulator_ from [nickg/nvc](www.nickg.me.uk/nvc/).
 
 ## Tags
 | Tag(s) | NVC Version | LLVM Version | Note |

--- a/oss-cad-suite/README.md
+++ b/oss-cad-suite/README.md
@@ -2,7 +2,7 @@
 > This image is part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
 > For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
 
-This container contains a continerized version of `oss.cad.suite` - _open source digital design and verification tools_ from [YosysHQ/oss-cad-suite-build](https://github.com/YosysHQ/oss-cad-suite-build).
+This container contains a containerized version of `oss.cad.suite` - _open source digital design and verification tools_ from [YosysHQ/oss-cad-suite-build](https://github.com/YosysHQ/oss-cad-suite-build).
 
 ## Tags
 | Tag(s) | Version | Note |

--- a/quartus/README.md
+++ b/quartus/README.md
@@ -92,6 +92,7 @@ Feel free to open an issue to request other add-ons or additional versions.
 For improved functionality and ease-of-use you may want to add some of these arguments to the `docker run` command stated above:
  - Anything mentioned in [`dev-base`](../dev-base/README.md)
  - `--volume=/dev:/dev --privileged`: Allows USB/JTAG access to FPGAs for programming.
+ - `--net=host`: Use host network. This may be used to make UDP/TCP based services (like the JTAG server `jtagd`) available to other containers or the host.
 
 ## License
 [MIT](../LICENSE) © [NikLeberg](https://github.com/NikLeberg).

--- a/quartus/README.md
+++ b/quartus/README.md
@@ -2,7 +2,7 @@
 > These images are part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
 > For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
 
-These images contain a continerized version of `Quartus Prime <Version> Lite Edition` in various versions and supported devices.
+These images contain a containerized version of `Quartus Prime <Version> Lite Edition` in various versions and supported devices.
 
 Quartus is a part of [Altera Quartus Prime Lite](https://www.altera.com/products/development-tools/quartus). To reduce the size of the images the tools of Quartus have been split up into two image groups:
  - `quartus`, tools to synthesize HDL for Altera FPGAs (these one here)

--- a/questasim/README.md
+++ b/questasim/README.md
@@ -2,7 +2,7 @@
 > This image is part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
 > For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
 
-This container contains a continerized version of `Questa Altera Starter FPGA Edition-64 vsim <version`.
+This container contains a containerized version of `Questa Altera Starter FPGA Edition-64 vsim <version`.
 
 Questa is a part of [Altera Quartus Prime Lite](https://www.altera.com/products/development-tools/quartus). To reduce the size of the image the tools of Quartus have been split up into two images:
  - [`quartus`](../quartus/README.md), tools to synthesize HDL for Altera FPGAs

--- a/riscv-gcc/README.md
+++ b/riscv-gcc/README.md
@@ -2,7 +2,7 @@
 > This image is part of the dockerized tools meant to be used with image [`dev-base`](../dev-base/README.md) in GitHub Codespace or VsCode devcontainer environments.
 > For answers to general why? and how? consult the [README of dev-base](../dev-base/README.md).
 
-This container contains a continerized version of the RISC-V GCC cross-compiler toolchain in various versions, see [below](#tags).
+This container contains a containerized version of the RISC-V GCC cross-compiler toolchain in various versions, see [below](#tags).
 Additionally `make`, `openocd` and a host version of a `gcc` toolchain are installed as well.
 
 ## Tags


### PR DESCRIPTION
With implementation of `neorv32_debug_dtm.altera_sld.vhd` i.e. AJI/SLD based DTM in project [https://github.com/NikLeberg/bog_video](NikLeberg/bog_video), this image could finally be tested. It works!

Fixes #39